### PR TITLE
Ignore elements when processing emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ becomes
 
 ![Colon emoji inside the Imojify class are converted to real emoji](https://dl.dropboxusercontent.com/u/13316703/imojify/imojify_demo.png)
 
+## Ignoring elements
+
+If you have some elements within your source element that you don't want processed you can specify a selector to match all elements to ignore.
+
+```js
+imojify('.imojify', { ignore: '.ignore-emoji' });
+```
+
 ## Adding custom emoji
 
 If you're one of those people who thinks "There is no such thing as too much emoji", you can add your own emoji, including animated GIFs!

--- a/demo.html
+++ b/demo.html
@@ -7,12 +7,15 @@
   </head>
   <body class="imojify">
     <h1 title="don't > :cry: <">We :heart: emoji!</h1>
-    <p>:+1: This paragraph will be processed :tada:</p>
+    <p>
+      :+1: This paragraph will be processed :tada:
+      <span class="ignore-emoji">But this span will be ignored <em>:frowning:</em></span>
+    </p>
     <p>Timestamps and invalid emoji names are ignored e.g. 12:20:21 :not_a_real_emoji:</p>
     <p>Custom emoji is supported too! :upside_down_face:</p>
     <script src="js/imojify.js"></script>
     <script>
-      imojify(); // equivalent to imojify('.imojify')
+      imojify('.imojify', { ignore: '.ignore-emoji' });
     </script>
   </body>
 </html>

--- a/emojimap.json
+++ b/emojimap.json
@@ -1,6 +1,6 @@
 {
   "grinning": {
-    "unicode": "1f600",
+    "unicode": "1F600",
     "unicode_alternates": [],
     "name": "grinning face",
     "shortname": ":grinning:",
@@ -18,7 +18,7 @@
     ]
   },
   "grin": {
-    "unicode": "1f601",
+    "unicode": "1F601",
     "unicode_alternates": [],
     "name": "grinning face with smiling eyes",
     "shortname": ":grin:",
@@ -35,7 +35,7 @@
     ]
   },
   "joy": {
-    "unicode": "1f602",
+    "unicode": "1F602",
     "unicode_alternates": [],
     "name": "face with tears of joy",
     "shortname": ":joy:",
@@ -54,7 +54,7 @@
     ]
   },
   "smiley": {
-    "unicode": "1f603",
+    "unicode": "1F603",
     "unicode_alternates": [],
     "name": "smiling face with open mouth",
     "shortname": ":smiley:",
@@ -75,7 +75,7 @@
     ]
   },
   "smile": {
-    "unicode": "1f604",
+    "unicode": "1F604",
     "unicode_alternates": [],
     "name": "smiling face with open mouth and smiling eyes",
     "shortname": ":smile:",
@@ -100,7 +100,7 @@
     ]
   },
   "sweat_smile": {
-    "unicode": "1f605",
+    "unicode": "1F605",
     "unicode_alternates": [],
     "name": "smiling face with open mouth and cold sweat",
     "shortname": ":sweat_smile:",
@@ -123,7 +123,7 @@
     ]
   },
   "laughing": {
-    "unicode": "1f606",
+    "unicode": "1F606",
     "unicode_alternates": [],
     "name": "smiling face with open mouth and tightly-closed eyes",
     "shortname": ":laughing:",
@@ -147,7 +147,7 @@
     ]
   },
   "innocent": {
-    "unicode": "1f607",
+    "unicode": "1F607",
     "unicode_alternates": [],
     "name": "smiling face with halo",
     "shortname": ":innocent:",
@@ -177,7 +177,7 @@
     ]
   },
   "smiling_imp": {
-    "unicode": "1f608",
+    "unicode": "1F608",
     "unicode_alternates": [],
     "name": "smiling face with horns",
     "shortname": ":smiling_imp:",
@@ -193,7 +193,7 @@
     ]
   },
   "imp": {
-    "unicode": "1f47f",
+    "unicode": "1F47F",
     "unicode_alternates": [],
     "name": "imp",
     "shortname": ":imp:",
@@ -211,7 +211,7 @@
     ]
   },
   "wink": {
-    "unicode": "1f609",
+    "unicode": "1F609",
     "unicode_alternates": [],
     "name": "winking face",
     "shortname": ":wink:",
@@ -238,7 +238,7 @@
     ]
   },
   "blush": {
-    "unicode": "1f60a",
+    "unicode": "1F60A",
     "unicode_alternates": [],
     "name": "smiling face with smiling eyes",
     "shortname": ":blush:",
@@ -257,7 +257,7 @@
     ]
   },
   "relaxed": {
-    "unicode": "263a",
+    "unicode": "263A",
     "unicode_alternates": [
       "263A-FE0F"
     ],
@@ -276,7 +276,7 @@
     ]
   },
   "yum": {
-    "unicode": "1f60b",
+    "unicode": "1F60B",
     "unicode_alternates": [],
     "name": "face savouring delicious food",
     "shortname": ":yum:",
@@ -297,7 +297,7 @@
     ]
   },
   "relieved": {
-    "unicode": "1f60c",
+    "unicode": "1F60C",
     "unicode_alternates": [],
     "name": "relieved face",
     "shortname": ":relieved:",
@@ -315,7 +315,7 @@
     ]
   },
   "heart_eyes": {
-    "unicode": "1f60d",
+    "unicode": "1F60D",
     "unicode_alternates": [],
     "name": "smiling face with heart-shaped eyes",
     "shortname": ":heart_eyes:",
@@ -337,7 +337,7 @@
     ]
   },
   "sunglasses": {
-    "unicode": "1f60e",
+    "unicode": "1F60E",
     "unicode_alternates": [],
     "name": "smiling face with sunglasses",
     "shortname": ":sunglasses:",
@@ -361,7 +361,7 @@
     ]
   },
   "smirk": {
-    "unicode": "1f60f",
+    "unicode": "1F60F",
     "unicode_alternates": [],
     "name": "smirking face",
     "shortname": ":smirk:",
@@ -380,7 +380,7 @@
     ]
   },
   "neutral_face": {
-    "unicode": "1f610",
+    "unicode": "1F610",
     "unicode_alternates": [],
     "name": "neutral face",
     "shortname": ":neutral_face:",
@@ -396,7 +396,7 @@
     ]
   },
   "expressionless": {
-    "unicode": "1f611",
+    "unicode": "1F611",
     "unicode_alternates": [],
     "name": "expressionless face",
     "shortname": ":expressionless:",
@@ -417,7 +417,7 @@
     ]
   },
   "unamused": {
-    "unicode": "1f612",
+    "unicode": "1F612",
     "unicode_alternates": [],
     "name": "unamused face",
     "shortname": ":unamused:",
@@ -438,7 +438,7 @@
     ]
   },
   "sweat": {
-    "unicode": "1f613",
+    "unicode": "1F613",
     "unicode_alternates": [],
     "name": "face with cold sweat",
     "shortname": ":sweat:",
@@ -460,7 +460,7 @@
     ]
   },
   "pensive": {
-    "unicode": "1f614",
+    "unicode": "1F614",
     "unicode_alternates": [],
     "name": "pensive face",
     "shortname": ":pensive:",
@@ -480,7 +480,7 @@
     ]
   },
   "confused": {
-    "unicode": "1f615",
+    "unicode": "1F615",
     "unicode_alternates": [],
     "name": "confused face",
     "shortname": ":confused:",
@@ -511,7 +511,7 @@
     ]
   },
   "confounded": {
-    "unicode": "1f616",
+    "unicode": "1F616",
     "unicode_alternates": [],
     "name": "confounded face",
     "shortname": ":confounded:",
@@ -530,7 +530,7 @@
     ]
   },
   "kissing": {
-    "unicode": "1f617",
+    "unicode": "1F617",
     "unicode_alternates": [],
     "name": "kissing face",
     "shortname": ":kissing:",
@@ -551,7 +551,7 @@
     ]
   },
   "kissing_heart": {
-    "unicode": "1f618",
+    "unicode": "1F618",
     "unicode_alternates": [],
     "name": "face throwing a kiss",
     "shortname": ":kissing_heart:",
@@ -576,7 +576,7 @@
     ]
   },
   "kissing_smiling_eyes": {
-    "unicode": "1f619",
+    "unicode": "1F619",
     "unicode_alternates": [],
     "name": "kissing face with smiling eyes",
     "shortname": ":kissing_smiling_eyes:",
@@ -596,7 +596,7 @@
     ]
   },
   "kissing_closed_eyes": {
-    "unicode": "1f61a",
+    "unicode": "1F61A",
     "unicode_alternates": [],
     "name": "kissing face with closed eyes",
     "shortname": ":kissing_closed_eyes:",
@@ -618,7 +618,7 @@
     ]
   },
   "stuck_out_tongue": {
-    "unicode": "1f61b",
+    "unicode": "1F61B",
     "unicode_alternates": [],
     "name": "face with stuck-out tongue",
     "shortname": ":stuck_out_tongue:",
@@ -651,7 +651,7 @@
     ]
   },
   "stuck_out_tongue_winking_eye": {
-    "unicode": "1f61c",
+    "unicode": "1F61C",
     "unicode_alternates": [],
     "name": "face with stuck-out tongue and winking eye",
     "shortname": ":stuck_out_tongue_winking_eye:",
@@ -676,7 +676,7 @@
     ]
   },
   "stuck_out_tongue_closed_eyes": {
-    "unicode": "1f61d",
+    "unicode": "1F61D",
     "unicode_alternates": [],
     "name": "face with stuck-out tongue and tightly-closed eyes",
     "shortname": ":stuck_out_tongue_closed_eyes:",
@@ -695,7 +695,7 @@
     ]
   },
   "disappointed": {
-    "unicode": "1f61e",
+    "unicode": "1F61E",
     "unicode_alternates": [],
     "name": "disappointed face",
     "shortname": ":disappointed:",
@@ -720,7 +720,7 @@
     ]
   },
   "worried": {
-    "unicode": "1f61f",
+    "unicode": "1F61F",
     "unicode_alternates": [],
     "name": "worried face",
     "shortname": ":worried:",
@@ -737,7 +737,7 @@
     ]
   },
   "angry": {
-    "unicode": "1f620",
+    "unicode": "1F620",
     "unicode_alternates": [],
     "name": "angry face",
     "shortname": ":angry:",
@@ -759,7 +759,7 @@
     ]
   },
   "rage": {
-    "unicode": "1f621",
+    "unicode": "1F621",
     "unicode_alternates": [],
     "name": "pouting face",
     "shortname": ":rage:",
@@ -779,7 +779,7 @@
     ]
   },
   "cry": {
-    "unicode": "1f622",
+    "unicode": "1F622",
     "unicode_alternates": [],
     "name": "crying face",
     "shortname": ":cry:",
@@ -800,7 +800,7 @@
     ]
   },
   "persevere": {
-    "unicode": "1f623",
+    "unicode": "1F623",
     "unicode_alternates": [],
     "name": "persevering face",
     "shortname": ":persevere:",
@@ -819,7 +819,7 @@
     ]
   },
   "triumph": {
-    "unicode": "1f624",
+    "unicode": "1F624",
     "unicode_alternates": [],
     "name": "face with look of triumph",
     "shortname": ":triumph:",
@@ -835,7 +835,7 @@
     ]
   },
   "disappointed_relieved": {
-    "unicode": "1f625",
+    "unicode": "1F625",
     "unicode_alternates": [],
     "name": "disappointed but relieved face",
     "shortname": ":disappointed_relieved:",
@@ -851,7 +851,7 @@
     ]
   },
   "frowning": {
-    "unicode": "1f626",
+    "unicode": "1F626",
     "unicode_alternates": [],
     "name": "frowning face with open mouth",
     "shortname": ":frowning:",
@@ -869,7 +869,7 @@
     ]
   },
   "anguished": {
-    "unicode": "1f627",
+    "unicode": "1F627",
     "unicode_alternates": [],
     "name": "anguished face",
     "shortname": ":anguished:",
@@ -889,7 +889,7 @@
     ]
   },
   "fearful": {
-    "unicode": "1f628",
+    "unicode": "1F628",
     "unicode_alternates": [],
     "name": "fearful face",
     "shortname": ":fearful:",
@@ -907,7 +907,7 @@
     ]
   },
   "weary": {
-    "unicode": "1f629",
+    "unicode": "1F629",
     "unicode_alternates": [],
     "name": "weary face",
     "shortname": ":weary:",
@@ -928,7 +928,7 @@
     ]
   },
   "sleepy": {
-    "unicode": "1f62a",
+    "unicode": "1F62A",
     "unicode_alternates": [],
     "name": "sleepy face",
     "shortname": ":sleepy:",
@@ -943,7 +943,7 @@
     ]
   },
   "tired_face": {
-    "unicode": "1f62b",
+    "unicode": "1F62B",
     "unicode_alternates": [],
     "name": "tired face",
     "shortname": ":tired_face:",
@@ -961,7 +961,7 @@
     ]
   },
   "grimacing": {
-    "unicode": "1f62c",
+    "unicode": "1F62C",
     "unicode_alternates": [],
     "name": "grimacing face",
     "shortname": ":grimacing:",
@@ -977,7 +977,7 @@
     ]
   },
   "sob": {
-    "unicode": "1f62d",
+    "unicode": "1F62D",
     "unicode_alternates": [],
     "name": "loudly crying face",
     "shortname": ":sob:",
@@ -998,7 +998,7 @@
     ]
   },
   "open_mouth": {
-    "unicode": "1f62e",
+    "unicode": "1F62E",
     "unicode_alternates": [],
     "name": "face with open mouth",
     "shortname": ":open_mouth:",
@@ -1022,7 +1022,7 @@
     ]
   },
   "hushed": {
-    "unicode": "1f62f",
+    "unicode": "1F62F",
     "unicode_alternates": [],
     "name": "hushed face",
     "shortname": ":hushed:",
@@ -1039,7 +1039,7 @@
     ]
   },
   "cold_sweat": {
-    "unicode": "1f630",
+    "unicode": "1F630",
     "unicode_alternates": [],
     "name": "face with open mouth and cold sweat",
     "shortname": ":cold_sweat:",
@@ -1054,7 +1054,7 @@
     ]
   },
   "scream": {
-    "unicode": "1f631",
+    "unicode": "1F631",
     "unicode_alternates": [],
     "name": "face screaming in fear",
     "shortname": ":scream:",
@@ -1071,7 +1071,7 @@
     ]
   },
   "astonished": {
-    "unicode": "1f632",
+    "unicode": "1F632",
     "unicode_alternates": [],
     "name": "astonished face",
     "shortname": ":astonished:",
@@ -1086,7 +1086,7 @@
     ]
   },
   "flushed": {
-    "unicode": "1f633",
+    "unicode": "1F633",
     "unicode_alternates": [],
     "name": "flushed face",
     "shortname": ":flushed:",
@@ -1109,7 +1109,7 @@
     ]
   },
   "sleeping": {
-    "unicode": "1f634",
+    "unicode": "1F634",
     "unicode_alternates": [],
     "name": "sleeping face",
     "shortname": ":sleeping:",
@@ -1126,7 +1126,7 @@
     ]
   },
   "dizzy_face": {
-    "unicode": "1f635",
+    "unicode": "1F635",
     "unicode_alternates": [],
     "name": "dizzy face",
     "shortname": ":dizzy_face:",
@@ -1151,7 +1151,7 @@
     ]
   },
   "no_mouth": {
-    "unicode": "1f636",
+    "unicode": "1F636",
     "unicode_alternates": [],
     "name": "face without mouth",
     "shortname": ":no_mouth:",
@@ -1176,7 +1176,7 @@
     ]
   },
   "mask": {
-    "unicode": "1f637",
+    "unicode": "1F637",
     "unicode_alternates": [],
     "name": "face with medical mask",
     "shortname": ":mask:",
@@ -1192,7 +1192,7 @@
     ]
   },
   "slight_frown": {
-    "unicode": "1f641",
+    "unicode": "1F641",
     "unicode_alternates": [],
     "name": "slightly frowning face",
     "shortname": ":slight_frown:",
@@ -1210,7 +1210,7 @@
     ]
   },
   "slight_smile": {
-    "unicode": "1f642",
+    "unicode": "1F642",
     "unicode_alternates": [],
     "name": "slightly smiling face",
     "shortname": ":slight_smile:",
@@ -1227,7 +1227,7 @@
     ]
   },
   "smile_cat": {
-    "unicode": "1f638",
+    "unicode": "1F638",
     "unicode_alternates": [],
     "name": "grinning cat face with smiling eyes",
     "shortname": ":smile_cat:",
@@ -1243,7 +1243,7 @@
     ]
   },
   "joy_cat": {
-    "unicode": "1f639",
+    "unicode": "1F639",
     "unicode_alternates": [],
     "name": "cat face with tears of joy",
     "shortname": ":joy_cat:",
@@ -1264,7 +1264,7 @@
     ]
   },
   "smiley_cat": {
-    "unicode": "1f63a",
+    "unicode": "1F63A",
     "unicode_alternates": [],
     "name": "smiling cat face with open mouth",
     "shortname": ":smiley_cat:",
@@ -1281,7 +1281,7 @@
     ]
   },
   "heart_eyes_cat": {
-    "unicode": "1f63b",
+    "unicode": "1F63B",
     "unicode_alternates": [],
     "name": "smiling cat face with heart-shaped eyes",
     "shortname": ":heart_eyes_cat:",
@@ -1302,7 +1302,7 @@
     ]
   },
   "smirk_cat": {
-    "unicode": "1f63c",
+    "unicode": "1F63C",
     "unicode_alternates": [],
     "name": "cat face with wry smile",
     "shortname": ":smirk_cat:",
@@ -1320,7 +1320,7 @@
     ]
   },
   "kissing_cat": {
-    "unicode": "1f63d",
+    "unicode": "1F63D",
     "unicode_alternates": [],
     "name": "kissing cat face with closed eyes",
     "shortname": ":kissing_cat:",
@@ -1339,7 +1339,7 @@
     ]
   },
   "pouting_cat": {
-    "unicode": "1f63e",
+    "unicode": "1F63E",
     "unicode_alternates": [],
     "name": "pouting cat face",
     "shortname": ":pouting_cat:",
@@ -1358,7 +1358,7 @@
     ]
   },
   "crying_cat_face": {
-    "unicode": "1f63f",
+    "unicode": "1F63F",
     "unicode_alternates": [],
     "name": "crying cat face",
     "shortname": ":crying_cat_face:",
@@ -1383,7 +1383,7 @@
     ]
   },
   "scream_cat": {
-    "unicode": "1f640",
+    "unicode": "1F640",
     "unicode_alternates": [],
     "name": "weary cat face",
     "shortname": ":scream_cat:",
@@ -1408,7 +1408,7 @@
     ]
   },
   "footprints": {
-    "unicode": "1f463",
+    "unicode": "1F463",
     "unicode_alternates": [],
     "name": "footprints",
     "shortname": ":footprints:",
@@ -1421,7 +1421,7 @@
     ]
   },
   "bust_in_silhouette": {
-    "unicode": "1f464",
+    "unicode": "1F464",
     "unicode_alternates": [],
     "name": "bust in silhouette",
     "shortname": ":bust_in_silhouette:",
@@ -1446,7 +1446,7 @@
     ]
   },
   "busts_in_silhouette": {
-    "unicode": "1f465",
+    "unicode": "1F465",
     "unicode_alternates": [],
     "name": "busts in silhouette",
     "shortname": ":busts_in_silhouette:",
@@ -1469,7 +1469,7 @@
     ]
   },
   "levitate": {
-    "unicode": "1f574",
+    "unicode": "1F574",
     "unicode_alternates": [],
     "name": "man in business suit levitating",
     "shortname": ":levitate:",
@@ -1485,7 +1485,7 @@
     ]
   },
   "spy": {
-    "unicode": "1f575",
+    "unicode": "1F575",
     "unicode_alternates": [],
     "name": "sleuth or spy",
     "shortname": ":spy:",
@@ -1502,7 +1502,7 @@
     ]
   },
   "baby": {
-    "unicode": "1f476",
+    "unicode": "1F476",
     "unicode_alternates": [],
     "name": "baby",
     "shortname": ":baby:",
@@ -1517,7 +1517,7 @@
     ]
   },
   "boy": {
-    "unicode": "1f466",
+    "unicode": "1F466",
     "unicode_alternates": [],
     "name": "boy",
     "shortname": ":boy:",
@@ -1532,7 +1532,7 @@
     ]
   },
   "girl": {
-    "unicode": "1f467",
+    "unicode": "1F467",
     "unicode_alternates": [],
     "name": "girl",
     "shortname": ":girl:",
@@ -1547,7 +1547,7 @@
     ]
   },
   "man": {
-    "unicode": "1f468",
+    "unicode": "1F468",
     "unicode_alternates": [],
     "name": "man",
     "shortname": ":man:",
@@ -1564,7 +1564,7 @@
     ]
   },
   "woman": {
-    "unicode": "1f469",
+    "unicode": "1F469",
     "unicode_alternates": [],
     "name": "woman",
     "shortname": ":woman:",
@@ -1579,7 +1579,7 @@
     ]
   },
   "family": {
-    "unicode": "1f46a",
+    "unicode": "1F46A",
     "unicode_alternates": [],
     "name": "family",
     "shortname": ":family:",
@@ -1603,7 +1603,7 @@
     ]
   },
   "family_mwg": {
-    "unicode": "1f468-1F469-1F467",
+    "unicode": "1F468-1F469-1F467",
     "unicode_alternates": [
       "1F468-200D-1F469-200D-1F467"
     ],
@@ -1629,7 +1629,7 @@
     ]
   },
   "family_mwgb": {
-    "unicode": "1f468-1F469-1F467-1F466",
+    "unicode": "1F468-1F469-1F467-1F466",
     "unicode_alternates": [
       "1F468-200D-1F469-200D-1F467-200D-1F466"
     ],
@@ -1655,7 +1655,7 @@
     ]
   },
   "family_mwbb": {
-    "unicode": "1f468-1F469-1F466-1F466",
+    "unicode": "1F468-1F469-1F466-1F466",
     "unicode_alternates": [
       "1F468-200D-1F469-200D-1F466-200D-1F466"
     ],
@@ -1680,7 +1680,7 @@
     ]
   },
   "family_mwgg": {
-    "unicode": "1f468-1F469-1F467-1F467",
+    "unicode": "1F468-1F469-1F467-1F467",
     "unicode_alternates": [
       "1F468-200D-1F469-200D-1F467-200D-1F467"
     ],
@@ -1705,7 +1705,7 @@
     ]
   },
   "family_wwb": {
-    "unicode": "1f469-1F469-1F466",
+    "unicode": "1F469-1F469-1F466",
     "unicode_alternates": [
       "1F469-200D-1F469-200D-1F466"
     ],
@@ -1730,7 +1730,7 @@
     ]
   },
   "family_wwg": {
-    "unicode": "1f469-1F469-1F467",
+    "unicode": "1F469-1F469-1F467",
     "unicode_alternates": [
       "1F469-200D-1F469-200D-1F467"
     ],
@@ -1755,7 +1755,7 @@
     ]
   },
   "family_wwgb": {
-    "unicode": "1f469-1F469-1F467-1F466",
+    "unicode": "1F469-1F469-1F467-1F466",
     "unicode_alternates": [
       "1F469-200D-1F469-200D-1F467-200D-1F466"
     ],
@@ -1781,7 +1781,7 @@
     ]
   },
   "family_wwbb": {
-    "unicode": "1f469-1F469-1F466-1F466",
+    "unicode": "1F469-1F469-1F466-1F466",
     "unicode_alternates": [
       "1F469-200D-1F469-200D-1F466-200D-1F466"
     ],
@@ -1806,7 +1806,7 @@
     ]
   },
   "family_wwgg": {
-    "unicode": "1f469-1F469-1F467-1F467",
+    "unicode": "1F469-1F469-1F467-1F467",
     "unicode_alternates": [
       "1F469-200D-1F469-200D-1F467-200D-1F467"
     ],
@@ -1831,7 +1831,7 @@
     ]
   },
   "family_mmb": {
-    "unicode": "1f468-1F468-1F466",
+    "unicode": "1F468-1F468-1F466",
     "unicode_alternates": [
       "1F468-200D-1F468-200D-1F466"
     ],
@@ -1855,7 +1855,7 @@
     ]
   },
   "family_mmg": {
-    "unicode": "1f468-1F468-1F467",
+    "unicode": "1F468-1F468-1F467",
     "unicode_alternates": [
       "1F468-200D-1F468-200D-1F467"
     ],
@@ -1879,7 +1879,7 @@
     ]
   },
   "family_mmgb": {
-    "unicode": "1f468-1F468-1F467-1F466",
+    "unicode": "1F468-1F468-1F467-1F466",
     "unicode_alternates": [
       "1F468-200D-1F468-200D-1F467-200D-1F466"
     ],
@@ -1904,7 +1904,7 @@
     ]
   },
   "family_mmbb": {
-    "unicode": "1f468-1F468-1F466-1F466",
+    "unicode": "1F468-1F468-1F466-1F466",
     "unicode_alternates": [
       "1F468-200D-1F468-200D-1F466-200D-1F466"
     ],
@@ -1928,7 +1928,7 @@
     ]
   },
   "family_mmgg": {
-    "unicode": "1f468-1F468-1F467-1F467",
+    "unicode": "1F468-1F468-1F467-1F467",
     "unicode_alternates": [
       "1F468-200D-1F468-200D-1F467-200D-1F467"
     ],
@@ -1952,7 +1952,7 @@
     ]
   },
   "couple": {
-    "unicode": "1f46b",
+    "unicode": "1F46B",
     "unicode_alternates": [],
     "name": "man and woman holding hands",
     "shortname": ":couple:",
@@ -1973,7 +1973,7 @@
     ]
   },
   "two_men_holding_hands": {
-    "unicode": "1f46c",
+    "unicode": "1F46C",
     "unicode_alternates": [],
     "name": "two men holding hands",
     "shortname": ":two_men_holding_hands:",
@@ -1995,7 +1995,7 @@
     ]
   },
   "two_women_holding_hands": {
-    "unicode": "1f46d",
+    "unicode": "1F46D",
     "unicode_alternates": [],
     "name": "two women holding hands",
     "shortname": ":two_women_holding_hands:",
@@ -2021,7 +2021,7 @@
     ]
   },
   "dancers": {
-    "unicode": "1f46f",
+    "unicode": "1F46F",
     "unicode_alternates": [],
     "name": "woman with bunny ears",
     "shortname": ":dancers:",
@@ -2042,7 +2042,7 @@
     ]
   },
   "bride_with_veil": {
-    "unicode": "1f470",
+    "unicode": "1F470",
     "unicode_alternates": [],
     "name": "bride with veil",
     "shortname": ":bride_with_veil:",
@@ -2063,7 +2063,7 @@
     ]
   },
   "person_with_blond_hair": {
-    "unicode": "1f471",
+    "unicode": "1F471",
     "unicode_alternates": [],
     "name": "person with blond hair",
     "shortname": ":person_with_blond_hair:",
@@ -2082,7 +2082,7 @@
     ]
   },
   "man_with_gua_pi_mao": {
-    "unicode": "1f472",
+    "unicode": "1F472",
     "unicode_alternates": [],
     "name": "man with gua pi mao",
     "shortname": ":man_with_gua_pi_mao:",
@@ -2100,7 +2100,7 @@
     ]
   },
   "man_with_turban": {
-    "unicode": "1f473",
+    "unicode": "1F473",
     "unicode_alternates": [],
     "name": "man with turban",
     "shortname": ":man_with_turban:",
@@ -2121,7 +2121,7 @@
     ]
   },
   "older_man": {
-    "unicode": "1f474",
+    "unicode": "1F474",
     "unicode_alternates": [],
     "name": "older man",
     "shortname": ":older_man:",
@@ -2135,7 +2135,7 @@
     ]
   },
   "older_woman": {
-    "unicode": "1f475",
+    "unicode": "1F475",
     "unicode_alternates": [],
     "name": "older woman",
     "shortname": ":older_woman:",
@@ -2154,7 +2154,7 @@
     ]
   },
   "cop": {
-    "unicode": "1f46e",
+    "unicode": "1F46E",
     "unicode_alternates": [],
     "name": "police officer",
     "shortname": ":cop:",
@@ -2171,7 +2171,7 @@
     ]
   },
   "construction_worker": {
-    "unicode": "1f477",
+    "unicode": "1F477",
     "unicode_alternates": [],
     "name": "construction worker",
     "shortname": ":construction_worker:",
@@ -2187,7 +2187,7 @@
     ]
   },
   "princess": {
-    "unicode": "1f478",
+    "unicode": "1F478",
     "unicode_alternates": [],
     "name": "princess",
     "shortname": ":princess:",
@@ -2211,7 +2211,7 @@
     ]
   },
   "guardsman": {
-    "unicode": "1f482",
+    "unicode": "1F482",
     "unicode_alternates": [],
     "name": "guardsman",
     "shortname": ":guardsman:",
@@ -2235,7 +2235,7 @@
     ]
   },
   "angel": {
-    "unicode": "1f47c",
+    "unicode": "1F47C",
     "unicode_alternates": [],
     "name": "baby angel",
     "shortname": ":angel:",
@@ -2252,7 +2252,7 @@
     ]
   },
   "santa": {
-    "unicode": "1f385",
+    "unicode": "1F385",
     "unicode_alternates": [],
     "name": "father christmas",
     "shortname": ":santa:",
@@ -2279,7 +2279,7 @@
     ]
   },
   "ghost": {
-    "unicode": "1f47b",
+    "unicode": "1F47B",
     "unicode_alternates": [],
     "name": "ghost",
     "shortname": ":ghost:",
@@ -2292,7 +2292,7 @@
     ]
   },
   "japanese_ogre": {
-    "unicode": "1f479",
+    "unicode": "1F479",
     "unicode_alternates": [],
     "name": "japanese ogre",
     "shortname": ":japanese_ogre:",
@@ -2315,7 +2315,7 @@
     ]
   },
   "japanese_goblin": {
-    "unicode": "1f47a",
+    "unicode": "1F47A",
     "unicode_alternates": [],
     "name": "japanese goblin",
     "shortname": ":japanese_goblin:",
@@ -2341,7 +2341,7 @@
     ]
   },
   "poop": {
-    "unicode": "1f4a9",
+    "unicode": "1F4A9",
     "unicode_alternates": [],
     "name": "pile of poo",
     "shortname": ":poop:",
@@ -2361,7 +2361,7 @@
     ]
   },
   "skull": {
-    "unicode": "1f480",
+    "unicode": "1F480",
     "unicode_alternates": [],
     "name": "skull",
     "shortname": ":skull:",
@@ -2379,7 +2379,7 @@
     ]
   },
   "alien": {
-    "unicode": "1f47d",
+    "unicode": "1F47D",
     "unicode_alternates": [],
     "name": "extraterrestrial alien",
     "shortname": ":alien:",
@@ -2394,7 +2394,7 @@
     ]
   },
   "space_invader": {
-    "unicode": "1f47e",
+    "unicode": "1F47E",
     "unicode_alternates": [],
     "name": "alien monster",
     "shortname": ":space_invader:",
@@ -2410,7 +2410,7 @@
     ]
   },
   "bow": {
-    "unicode": "1f647",
+    "unicode": "1F647",
     "unicode_alternates": [],
     "name": "person bowing deeply",
     "shortname": ":bow:",
@@ -2429,7 +2429,7 @@
     ]
   },
   "information_desk_person": {
-    "unicode": "1f481",
+    "unicode": "1F481",
     "unicode_alternates": [],
     "name": "information desk person",
     "shortname": ":information_desk_person:",
@@ -2452,7 +2452,7 @@
     ]
   },
   "no_good": {
-    "unicode": "1f645",
+    "unicode": "1F645",
     "unicode_alternates": [],
     "name": "face with no good gesture",
     "shortname": ":no_good:",
@@ -2471,7 +2471,7 @@
     ]
   },
   "ok_woman": {
-    "unicode": "1f646",
+    "unicode": "1F646",
     "unicode_alternates": [],
     "name": "face with ok gesture",
     "shortname": ":ok_woman:",
@@ -2496,7 +2496,7 @@
     ]
   },
   "raising_hand": {
-    "unicode": "1f64b",
+    "unicode": "1F64B",
     "unicode_alternates": [],
     "name": "happy person raising one hand",
     "shortname": ":raising_hand:",
@@ -2515,7 +2515,7 @@
     ]
   },
   "person_with_pouting_face": {
-    "unicode": "1f64e",
+    "unicode": "1F64E",
     "unicode_alternates": [],
     "name": "person with pouting face",
     "shortname": ":person_with_pouting_face:",
@@ -2534,7 +2534,7 @@
     ]
   },
   "person_frowning": {
-    "unicode": "1f64d",
+    "unicode": "1F64D",
     "unicode_alternates": [],
     "name": "person frowning",
     "shortname": ":person_frowning:",
@@ -2553,7 +2553,7 @@
     ]
   },
   "massage": {
-    "unicode": "1f486",
+    "unicode": "1F486",
     "unicode_alternates": [],
     "name": "face massage",
     "shortname": ":massage:",
@@ -2568,7 +2568,7 @@
     ]
   },
   "haircut": {
-    "unicode": "1f487",
+    "unicode": "1F487",
     "unicode_alternates": [],
     "name": "haircut",
     "shortname": ":haircut:",
@@ -2583,7 +2583,7 @@
     ]
   },
   "couple_with_heart": {
-    "unicode": "1f491",
+    "unicode": "1F491",
     "unicode_alternates": [],
     "name": "couple with heart",
     "shortname": ":couple_with_heart:",
@@ -2602,7 +2602,7 @@
     ]
   },
   "couple_ww": {
-    "unicode": "1f469-2764-1F469",
+    "unicode": "1F469-2764-1F469",
     "unicode_alternates": [
       "1F469-200D-2764-FE0F-200D-1F469"
     ],
@@ -2625,7 +2625,7 @@
     ]
   },
   "couple_mm": {
-    "unicode": "1f468-2764-1F468",
+    "unicode": "1F468-2764-1F468",
     "unicode_alternates": [
       "1F468-200D-2764-FE0F-200D-1F468"
     ],
@@ -2648,7 +2648,7 @@
     ]
   },
   "couplekiss": {
-    "unicode": "1f48f",
+    "unicode": "1F48F",
     "unicode_alternates": [],
     "name": "kiss",
     "shortname": ":couplekiss:",
@@ -2666,7 +2666,7 @@
     ]
   },
   "kiss_ww": {
-    "unicode": "1f469-2764-1F48B-1F469",
+    "unicode": "1F469-2764-1F48B-1F469",
     "unicode_alternates": [
       "1F469-200D-2764-FE0F-200D-1F48B-200D-1F469"
     ],
@@ -2688,7 +2688,7 @@
     ]
   },
   "kiss_mm": {
-    "unicode": "1f468-2764-1F48B-1F468",
+    "unicode": "1F468-2764-1F48B-1F468",
     "unicode_alternates": [
       "1F468-200D-2764-FE0F-200D-1F48B-200D-1F468"
     ],
@@ -2710,7 +2710,7 @@
     ]
   },
   "raised_hands": {
-    "unicode": "1f64c",
+    "unicode": "1F64C",
     "unicode_alternates": [],
     "name": "person raising both hands in celebration",
     "shortname": ":raised_hands:",
@@ -2729,7 +2729,7 @@
     ]
   },
   "clap": {
-    "unicode": "1f44f",
+    "unicode": "1F44F",
     "unicode_alternates": [],
     "name": "clapping hands sign",
     "shortname": ":clap:",
@@ -2750,7 +2750,7 @@
     ]
   },
   "ear": {
-    "unicode": "1f442",
+    "unicode": "1F442",
     "unicode_alternates": [],
     "name": "ear",
     "shortname": ":ear:",
@@ -2765,7 +2765,7 @@
     ]
   },
   "eye": {
-    "unicode": "1f441",
+    "unicode": "1F441",
     "unicode_alternates": [],
     "name": "eye",
     "shortname": ":eye:",
@@ -2780,7 +2780,7 @@
     ]
   },
   "eyes": {
-    "unicode": "1f440",
+    "unicode": "1F440",
     "unicode_alternates": [],
     "name": "eyes",
     "shortname": ":eyes:",
@@ -2796,7 +2796,7 @@
     ]
   },
   "nose": {
-    "unicode": "1f443",
+    "unicode": "1F443",
     "unicode_alternates": [],
     "name": "nose",
     "shortname": ":nose:",
@@ -2810,7 +2810,7 @@
     ]
   },
   "lips": {
-    "unicode": "1f444",
+    "unicode": "1F444",
     "unicode_alternates": [],
     "name": "mouth",
     "shortname": ":lips:",
@@ -2825,7 +2825,7 @@
     ]
   },
   "lips2": {
-    "unicode": "1f5e2",
+    "unicode": "1F5E2",
     "unicode_alternates": [],
     "name": "lips",
     "shortname": ":lips2:",
@@ -2839,7 +2839,7 @@
     ]
   },
   "kiss": {
-    "unicode": "1f48b",
+    "unicode": "1F48B",
     "unicode_alternates": [],
     "name": "kiss mark",
     "shortname": ":kiss:",
@@ -2857,7 +2857,7 @@
     ]
   },
   "tongue": {
-    "unicode": "1f445",
+    "unicode": "1F445",
     "unicode_alternates": [],
     "name": "tongue",
     "shortname": ":tongue:",
@@ -2884,7 +2884,7 @@
     ]
   },
   "nail_care": {
-    "unicode": "1f485",
+    "unicode": "1F485",
     "unicode_alternates": [],
     "name": "nail polish",
     "shortname": ":nail_care:",
@@ -2898,7 +2898,7 @@
     ]
   },
   "wave": {
-    "unicode": "1f44b",
+    "unicode": "1F44B",
     "unicode_alternates": [],
     "name": "waving hand sign",
     "shortname": ":wave:",
@@ -2916,7 +2916,7 @@
     ]
   },
   "thumbsup": {
-    "unicode": "1f44d",
+    "unicode": "1F44D",
     "unicode_alternates": [],
     "name": "thumbs up sign",
     "shortname": ":thumbsup:",
@@ -2935,7 +2935,7 @@
     ]
   },
   "thumbsdown": {
-    "unicode": "1f44e",
+    "unicode": "1F44E",
     "unicode_alternates": [],
     "name": "thumbs down sign",
     "shortname": ":thumbsdown:",
@@ -2952,7 +2952,7 @@
     ]
   },
   "point_up": {
-    "unicode": "261d",
+    "unicode": "261D",
     "unicode_alternates": [
       "261D-FE0F"
     ],
@@ -2970,7 +2970,7 @@
     ]
   },
   "point_up_2": {
-    "unicode": "1f446",
+    "unicode": "1F446",
     "unicode_alternates": [],
     "name": "white up pointing backhand index",
     "shortname": ":point_up_2:",
@@ -2986,7 +2986,7 @@
     ]
   },
   "point_down": {
-    "unicode": "1f447",
+    "unicode": "1F447",
     "unicode_alternates": [],
     "name": "white down pointing backhand index",
     "shortname": ":point_down:",
@@ -3001,7 +3001,7 @@
     ]
   },
   "point_left": {
-    "unicode": "1f448",
+    "unicode": "1F448",
     "unicode_alternates": [],
     "name": "white left pointing backhand index",
     "shortname": ":point_left:",
@@ -3016,7 +3016,7 @@
     ]
   },
   "point_right": {
-    "unicode": "1f449",
+    "unicode": "1F449",
     "unicode_alternates": [],
     "name": "white right pointing backhand index",
     "shortname": ":point_right:",
@@ -3031,7 +3031,7 @@
     ]
   },
   "ok_hand": {
-    "unicode": "1f44c",
+    "unicode": "1F44C",
     "unicode_alternates": [],
     "name": "ok hand sign",
     "shortname": ":ok_hand:",
@@ -3053,7 +3053,7 @@
     ]
   },
   "v": {
-    "unicode": "270c",
+    "unicode": "270C",
     "unicode_alternates": [
       "270C-FE0F"
     ],
@@ -3072,7 +3072,7 @@
     ]
   },
   "punch": {
-    "unicode": "1f44a",
+    "unicode": "1F44A",
     "unicode_alternates": [],
     "name": "fisted hand sign",
     "shortname": ":punch:",
@@ -3086,7 +3086,7 @@
     ]
   },
   "fist": {
-    "unicode": "270a",
+    "unicode": "270A",
     "unicode_alternates": [],
     "name": "raised fist",
     "shortname": ":fist:",
@@ -3101,7 +3101,7 @@
     ]
   },
   "raised_hand": {
-    "unicode": "270b",
+    "unicode": "270B",
     "unicode_alternates": [],
     "name": "raised hand",
     "shortname": ":raised_hand:",
@@ -3116,7 +3116,7 @@
     ]
   },
   "muscle": {
-    "unicode": "1f4aa",
+    "unicode": "1F4AA",
     "unicode_alternates": [],
     "name": "flexed biceps",
     "shortname": ":muscle:",
@@ -3134,7 +3134,7 @@
     ]
   },
   "open_hands": {
-    "unicode": "1f450",
+    "unicode": "1F450",
     "unicode_alternates": [],
     "name": "open hands sign",
     "shortname": ":open_hands:",
@@ -3148,7 +3148,7 @@
     ]
   },
   "writing_hand": {
-    "unicode": "1f58e",
+    "unicode": "1F58E",
     "unicode_alternates": [],
     "name": "left writing hand",
     "shortname": ":writing_hand:",
@@ -3166,7 +3166,7 @@
     ]
   },
   "turned_ok_hand": {
-    "unicode": "1f58f",
+    "unicode": "1F58F",
     "unicode_alternates": [],
     "name": "turned ok hand sign",
     "shortname": ":turned_ok_hand:",
@@ -3182,7 +3182,7 @@
     ]
   },
   "hand_splayed": {
-    "unicode": "1f590",
+    "unicode": "1F590",
     "unicode_alternates": [],
     "name": "raised hand with fingers splayed",
     "shortname": ":hand_splayed:",
@@ -3200,7 +3200,7 @@
     ]
   },
   "hand_splayed_reverse": {
-    "unicode": "1f591",
+    "unicode": "1F591",
     "unicode_alternates": [],
     "name": "reversed raised hand with fingers splayed",
     "shortname": ":hand_splayed_reverse:",
@@ -3218,7 +3218,7 @@
     ]
   },
   "thumbs_up_reverse": {
-    "unicode": "1f592",
+    "unicode": "1F592",
     "unicode_alternates": [],
     "name": "reversed thumbs up sign",
     "shortname": ":thumbs_up_reverse:",
@@ -3237,7 +3237,7 @@
     ]
   },
   "thumbs_down_reverse": {
-    "unicode": "1f593",
+    "unicode": "1F593",
     "unicode_alternates": [],
     "name": "reversed thumbs down sign",
     "shortname": ":thumbs_down_reverse:",
@@ -3254,7 +3254,7 @@
     ]
   },
   "hand_victory": {
-    "unicode": "1f594",
+    "unicode": "1F594",
     "unicode_alternates": [],
     "name": "reversed victory hand",
     "shortname": ":hand_victory:",
@@ -3269,7 +3269,7 @@
     ]
   },
   "middle_finger": {
-    "unicode": "1f595",
+    "unicode": "1F595",
     "unicode_alternates": [],
     "name": "reversed hand with middle finger extended",
     "shortname": ":middle_finger:",
@@ -3284,7 +3284,7 @@
     ]
   },
   "vulcan": {
-    "unicode": "1f596",
+    "unicode": "1F596",
     "unicode_alternates": [],
     "name": "raised hand with part between middle and ring fingers",
     "shortname": ":vulcan:",
@@ -3304,7 +3304,7 @@
     ]
   },
   "finger_pointing_down": {
-    "unicode": "1f597",
+    "unicode": "1F597",
     "unicode_alternates": [],
     "name": "white down pointing left hand index",
     "shortname": ":finger_pointing_down:",
@@ -3321,7 +3321,7 @@
     ]
   },
   "finger_pointing_left": {
-    "unicode": "1f598",
+    "unicode": "1F598",
     "unicode_alternates": [],
     "name": "sideways white left pointing index",
     "shortname": ":finger_pointing_left:",
@@ -3338,7 +3338,7 @@
     ]
   },
   "finger_pointing_right": {
-    "unicode": "1f599",
+    "unicode": "1F599",
     "unicode_alternates": [],
     "name": "sideways white right pointing index",
     "shortname": ":finger_pointing_right:",
@@ -3355,7 +3355,7 @@
     ]
   },
   "finger_pointing_up": {
-    "unicode": "1f59e",
+    "unicode": "1F59E",
     "unicode_alternates": [],
     "name": "sideways white up pointing index",
     "shortname": ":finger_pointing_up:",
@@ -3372,7 +3372,7 @@
     ]
   },
   "finger_pointing_down2": {
-    "unicode": "1f59f",
+    "unicode": "1F59F",
     "unicode_alternates": [],
     "name": "sideways white down pointing index",
     "shortname": ":finger_pointing_down2:",
@@ -3389,7 +3389,7 @@
     ]
   },
   "pray": {
-    "unicode": "1f64f",
+    "unicode": "1F64F",
     "unicode_alternates": [],
     "name": "person with folded hands",
     "shortname": ":pray:",
@@ -3411,7 +3411,7 @@
     ]
   },
   "seedling": {
-    "unicode": "1f331",
+    "unicode": "1F331",
     "unicode_alternates": [],
     "name": "seedling",
     "shortname": ":seedling:",
@@ -3430,7 +3430,7 @@
     ]
   },
   "evergreen_tree": {
-    "unicode": "1f332",
+    "unicode": "1F332",
     "unicode_alternates": [],
     "name": "evergreen tree",
     "shortname": ":evergreen_tree:",
@@ -3446,7 +3446,7 @@
     ]
   },
   "deciduous_tree": {
-    "unicode": "1f333",
+    "unicode": "1F333",
     "unicode_alternates": [],
     "name": "deciduous tree",
     "shortname": ":deciduous_tree:",
@@ -3463,7 +3463,7 @@
     ]
   },
   "palm_tree": {
-    "unicode": "1f334",
+    "unicode": "1F334",
     "unicode_alternates": [],
     "name": "palm tree",
     "shortname": ":palm_tree:",
@@ -3481,7 +3481,7 @@
     ]
   },
   "cactus": {
-    "unicode": "1f335",
+    "unicode": "1F335",
     "unicode_alternates": [],
     "name": "cactus",
     "shortname": ":cactus:",
@@ -3500,7 +3500,7 @@
     ]
   },
   "tulip": {
-    "unicode": "1f337",
+    "unicode": "1F337",
     "unicode_alternates": [],
     "name": "tulip",
     "shortname": ":tulip:",
@@ -3518,7 +3518,7 @@
     ]
   },
   "cherry_blossom": {
-    "unicode": "1f338",
+    "unicode": "1F338",
     "unicode_alternates": [],
     "name": "cherry blossom",
     "shortname": ":cherry_blossom:",
@@ -3534,7 +3534,7 @@
     ]
   },
   "rose": {
-    "unicode": "1f339",
+    "unicode": "1F339",
     "unicode_alternates": [],
     "name": "rose",
     "shortname": ":rose:",
@@ -3553,7 +3553,7 @@
     ]
   },
   "hibiscus": {
-    "unicode": "1f33a",
+    "unicode": "1F33A",
     "unicode_alternates": [],
     "name": "hibiscus",
     "shortname": ":hibiscus:",
@@ -3569,7 +3569,7 @@
     ]
   },
   "sunflower": {
-    "unicode": "1f33b",
+    "unicode": "1F33B",
     "unicode_alternates": [],
     "name": "sunflower",
     "shortname": ":sunflower:",
@@ -3587,7 +3587,7 @@
     ]
   },
   "blossom": {
-    "unicode": "1f33c",
+    "unicode": "1F33C",
     "unicode_alternates": [],
     "name": "blossom",
     "shortname": ":blossom:",
@@ -3603,7 +3603,7 @@
     ]
   },
   "bouquet": {
-    "unicode": "1f490",
+    "unicode": "1F490",
     "unicode_alternates": [],
     "name": "bouquet",
     "shortname": ":bouquet:",
@@ -3617,7 +3617,7 @@
     ]
   },
   "ear_of_rice": {
-    "unicode": "1f33e",
+    "unicode": "1F33E",
     "unicode_alternates": [],
     "name": "ear of rice",
     "shortname": ":ear_of_rice:",
@@ -3633,7 +3633,7 @@
     ]
   },
   "herb": {
-    "unicode": "1f33f",
+    "unicode": "1F33F",
     "unicode_alternates": [],
     "name": "herb",
     "shortname": ":herb:",
@@ -3655,7 +3655,7 @@
     ]
   },
   "four_leaf_clover": {
-    "unicode": "1f340",
+    "unicode": "1F340",
     "unicode_alternates": [],
     "name": "four leaf clover",
     "shortname": ":four_leaf_clover:",
@@ -3675,7 +3675,7 @@
     ]
   },
   "maple_leaf": {
-    "unicode": "1f341",
+    "unicode": "1F341",
     "unicode_alternates": [],
     "name": "maple leaf",
     "shortname": ":maple_leaf:",
@@ -3692,7 +3692,7 @@
     ]
   },
   "fallen_leaf": {
-    "unicode": "1f342",
+    "unicode": "1F342",
     "unicode_alternates": [],
     "name": "fallen leaf",
     "shortname": ":fallen_leaf:",
@@ -3712,7 +3712,7 @@
     ]
   },
   "leaves": {
-    "unicode": "1f343",
+    "unicode": "1F343",
     "unicode_alternates": [],
     "name": "leaf fluttering in wind",
     "shortname": ":leaves:",
@@ -3731,7 +3731,7 @@
     ]
   },
   "mushroom": {
-    "unicode": "1f344",
+    "unicode": "1F344",
     "unicode_alternates": [],
     "name": "mushroom",
     "shortname": ":mushroom:",
@@ -3749,7 +3749,7 @@
     ]
   },
   "chestnut": {
-    "unicode": "1f330",
+    "unicode": "1F330",
     "unicode_alternates": [],
     "name": "chestnut",
     "shortname": ":chestnut:",
@@ -3766,7 +3766,7 @@
     ]
   },
   "rat": {
-    "unicode": "1f400",
+    "unicode": "1F400",
     "unicode_alternates": [],
     "name": "rat",
     "shortname": ":rat:",
@@ -3783,7 +3783,7 @@
     ]
   },
   "mouse2": {
-    "unicode": "1f401",
+    "unicode": "1F401",
     "unicode_alternates": [],
     "name": "mouse",
     "shortname": ":mouse2:",
@@ -3799,7 +3799,7 @@
     ]
   },
   "mouse": {
-    "unicode": "1f42d",
+    "unicode": "1F42D",
     "unicode_alternates": [],
     "name": "mouse face",
     "shortname": ":mouse:",
@@ -3814,7 +3814,7 @@
     ]
   },
   "hamster": {
-    "unicode": "1f439",
+    "unicode": "1F439",
     "unicode_alternates": [],
     "name": "hamster face",
     "shortname": ":hamster:",
@@ -3829,7 +3829,7 @@
     ]
   },
   "ox": {
-    "unicode": "1f402",
+    "unicode": "1F402",
     "unicode_alternates": [],
     "name": "ox",
     "shortname": ":ox:",
@@ -3845,7 +3845,7 @@
     ]
   },
   "water_buffalo": {
-    "unicode": "1f403",
+    "unicode": "1F403",
     "unicode_alternates": [],
     "name": "water buffalo",
     "shortname": ":water_buffalo:",
@@ -3863,7 +3863,7 @@
     ]
   },
   "cow2": {
-    "unicode": "1f404",
+    "unicode": "1F404",
     "unicode_alternates": [],
     "name": "cow",
     "shortname": ":cow2:",
@@ -3884,7 +3884,7 @@
     ]
   },
   "cow": {
-    "unicode": "1f42e",
+    "unicode": "1F42E",
     "unicode_alternates": [],
     "name": "cow face",
     "shortname": ":cow:",
@@ -3901,7 +3901,7 @@
     ]
   },
   "tiger2": {
-    "unicode": "1f405",
+    "unicode": "1F405",
     "unicode_alternates": [],
     "name": "tiger",
     "shortname": ":tiger2:",
@@ -3920,7 +3920,7 @@
     ]
   },
   "leopard": {
-    "unicode": "1f406",
+    "unicode": "1F406",
     "unicode_alternates": [],
     "name": "leopard",
     "shortname": ":leopard:",
@@ -3938,7 +3938,7 @@
     ]
   },
   "tiger": {
-    "unicode": "1f42f",
+    "unicode": "1F42F",
     "unicode_alternates": [],
     "name": "tiger face",
     "shortname": ":tiger:",
@@ -3957,7 +3957,7 @@
     ]
   },
   "chipmunk": {
-    "unicode": "1f43f",
+    "unicode": "1F43F",
     "unicode_alternates": [],
     "name": "chipmunk",
     "shortname": ":chipmunk:",
@@ -3971,7 +3971,7 @@
     ]
   },
   "rabbit2": {
-    "unicode": "1f407",
+    "unicode": "1F407",
     "unicode_alternates": [],
     "name": "rabbit",
     "shortname": ":rabbit2:",
@@ -3989,7 +3989,7 @@
     ]
   },
   "rabbit": {
-    "unicode": "1f430",
+    "unicode": "1F430",
     "unicode_alternates": [],
     "name": "rabbit face",
     "shortname": ":rabbit:",
@@ -4007,7 +4007,7 @@
     ]
   },
   "cat2": {
-    "unicode": "1f408",
+    "unicode": "1F408",
     "unicode_alternates": [],
     "name": "cat",
     "shortname": ":cat2:",
@@ -4023,7 +4023,7 @@
     ]
   },
   "cat": {
-    "unicode": "1f431",
+    "unicode": "1F431",
     "unicode_alternates": [],
     "name": "cat face",
     "shortname": ":cat:",
@@ -4039,7 +4039,7 @@
     ]
   },
   "racehorse": {
-    "unicode": "1f40e",
+    "unicode": "1F40E",
     "unicode_alternates": [],
     "name": "horse",
     "shortname": ":racehorse:",
@@ -4071,7 +4071,7 @@
     ]
   },
   "horse": {
-    "unicode": "1f434",
+    "unicode": "1F434",
     "unicode_alternates": [],
     "name": "horse face",
     "shortname": ":horse:",
@@ -4094,7 +4094,7 @@
     ]
   },
   "ram": {
-    "unicode": "1f40f",
+    "unicode": "1F40F",
     "unicode_alternates": [],
     "name": "ram",
     "shortname": ":ram:",
@@ -4111,7 +4111,7 @@
     ]
   },
   "sheep": {
-    "unicode": "1f411",
+    "unicode": "1F411",
     "unicode_alternates": [],
     "name": "sheep",
     "shortname": ":sheep:",
@@ -4131,7 +4131,7 @@
     ]
   },
   "goat": {
-    "unicode": "1f410",
+    "unicode": "1F410",
     "unicode_alternates": [],
     "name": "goat",
     "shortname": ":goat:",
@@ -4148,7 +4148,7 @@
     ]
   },
   "rooster": {
-    "unicode": "1f413",
+    "unicode": "1F413",
     "unicode_alternates": [],
     "name": "rooster",
     "shortname": ":rooster:",
@@ -4168,7 +4168,7 @@
     ]
   },
   "chicken": {
-    "unicode": "1f414",
+    "unicode": "1F414",
     "unicode_alternates": [],
     "name": "chicken",
     "shortname": ":chicken:",
@@ -4185,7 +4185,7 @@
     ]
   },
   "baby_chick": {
-    "unicode": "1f424",
+    "unicode": "1F424",
     "unicode_alternates": [],
     "name": "baby chick",
     "shortname": ":baby_chick:",
@@ -4203,7 +4203,7 @@
     ]
   },
   "hatching_chick": {
-    "unicode": "1f423",
+    "unicode": "1F423",
     "unicode_alternates": [],
     "name": "hatching chick",
     "shortname": ":hatching_chick:",
@@ -4224,7 +4224,7 @@
     ]
   },
   "hatched_chick": {
-    "unicode": "1f425",
+    "unicode": "1F425",
     "unicode_alternates": [],
     "name": "front-facing baby chick",
     "shortname": ":hatched_chick:",
@@ -4245,7 +4245,7 @@
     ]
   },
   "bird": {
-    "unicode": "1f426",
+    "unicode": "1F426",
     "unicode_alternates": [],
     "name": "bird",
     "shortname": ":bird:",
@@ -4261,7 +4261,7 @@
     ]
   },
   "penguin": {
-    "unicode": "1f427",
+    "unicode": "1F427",
     "unicode_alternates": [],
     "name": "penguin",
     "shortname": ":penguin:",
@@ -4276,7 +4276,7 @@
     ]
   },
   "elephant": {
-    "unicode": "1f418",
+    "unicode": "1F418",
     "unicode_alternates": [],
     "name": "elephant",
     "shortname": ":elephant:",
@@ -4292,7 +4292,7 @@
     ]
   },
   "dromedary_camel": {
-    "unicode": "1f42a",
+    "unicode": "1F42A",
     "unicode_alternates": [],
     "name": "dromedary camel",
     "shortname": ":dromedary_camel:",
@@ -4314,7 +4314,7 @@
     ]
   },
   "camel": {
-    "unicode": "1f42b",
+    "unicode": "1F42B",
     "unicode_alternates": [],
     "name": "bactrian camel",
     "shortname": ":camel:",
@@ -4337,7 +4337,7 @@
     ]
   },
   "boar": {
-    "unicode": "1f417",
+    "unicode": "1F417",
     "unicode_alternates": [],
     "name": "boar",
     "shortname": ":boar:",
@@ -4351,7 +4351,7 @@
     ]
   },
   "pig2": {
-    "unicode": "1f416",
+    "unicode": "1F416",
     "unicode_alternates": [],
     "name": "pig",
     "shortname": ":pig2:",
@@ -4376,7 +4376,7 @@
     ]
   },
   "pig": {
-    "unicode": "1f437",
+    "unicode": "1F437",
     "unicode_alternates": [],
     "name": "pig face",
     "shortname": ":pig:",
@@ -4401,7 +4401,7 @@
     ]
   },
   "pig_nose": {
-    "unicode": "1f43d",
+    "unicode": "1F43D",
     "unicode_alternates": [],
     "name": "pig nose",
     "shortname": ":pig_nose:",
@@ -4422,7 +4422,7 @@
     ]
   },
   "dog2": {
-    "unicode": "1f415",
+    "unicode": "1F415",
     "unicode_alternates": [],
     "name": "dog",
     "shortname": ":dog2:",
@@ -4442,7 +4442,7 @@
     ]
   },
   "poodle": {
-    "unicode": "1f429",
+    "unicode": "1F429",
     "unicode_alternates": [],
     "name": "poodle",
     "shortname": ":poodle:",
@@ -4461,7 +4461,7 @@
     ]
   },
   "dog": {
-    "unicode": "1f436",
+    "unicode": "1F436",
     "unicode_alternates": [],
     "name": "dog face",
     "shortname": ":dog:",
@@ -4481,7 +4481,7 @@
     ]
   },
   "wolf": {
-    "unicode": "1f43a",
+    "unicode": "1F43A",
     "unicode_alternates": [],
     "name": "wolf face",
     "shortname": ":wolf:",
@@ -4495,7 +4495,7 @@
     ]
   },
   "bear": {
-    "unicode": "1f43b",
+    "unicode": "1F43B",
     "unicode_alternates": [],
     "name": "bear face",
     "shortname": ":bear:",
@@ -4510,7 +4510,7 @@
     ]
   },
   "koala": {
-    "unicode": "1f428",
+    "unicode": "1F428",
     "unicode_alternates": [],
     "name": "koala",
     "shortname": ":koala:",
@@ -4524,7 +4524,7 @@
     ]
   },
   "panda_face": {
-    "unicode": "1f43c",
+    "unicode": "1F43C",
     "unicode_alternates": [],
     "name": "panda face",
     "shortname": ":panda_face:",
@@ -4548,7 +4548,7 @@
     ]
   },
   "monkey_face": {
-    "unicode": "1f435",
+    "unicode": "1F435",
     "unicode_alternates": [],
     "name": "monkey face",
     "shortname": ":monkey_face:",
@@ -4562,7 +4562,7 @@
     ]
   },
   "see_no_evil": {
-    "unicode": "1f648",
+    "unicode": "1F648",
     "unicode_alternates": [],
     "name": "see-no-evil monkey",
     "shortname": ":see_no_evil:",
@@ -4582,7 +4582,7 @@
     ]
   },
   "hear_no_evil": {
-    "unicode": "1f649",
+    "unicode": "1F649",
     "unicode_alternates": [],
     "name": "hear-no-evil monkey",
     "shortname": ":hear_no_evil:",
@@ -4599,7 +4599,7 @@
     ]
   },
   "speak_no_evil": {
-    "unicode": "1f64a",
+    "unicode": "1F64A",
     "unicode_alternates": [],
     "name": "speak-no-evil monkey",
     "shortname": ":speak_no_evil:",
@@ -4620,7 +4620,7 @@
     ]
   },
   "monkey": {
-    "unicode": "1f412",
+    "unicode": "1F412",
     "unicode_alternates": [],
     "name": "monkey",
     "shortname": ":monkey:",
@@ -4637,7 +4637,7 @@
     ]
   },
   "dragon": {
-    "unicode": "1f409",
+    "unicode": "1F409",
     "unicode_alternates": [],
     "name": "dragon",
     "shortname": ":dragon:",
@@ -4657,7 +4657,7 @@
     ]
   },
   "dragon_face": {
-    "unicode": "1f432",
+    "unicode": "1F432",
     "unicode_alternates": [],
     "name": "dragon face",
     "shortname": ":dragon_face:",
@@ -4678,7 +4678,7 @@
     ]
   },
   "crocodile": {
-    "unicode": "1f40a",
+    "unicode": "1F40A",
     "unicode_alternates": [],
     "name": "crocodile",
     "shortname": ":crocodile:",
@@ -4696,7 +4696,7 @@
     ]
   },
   "snake": {
-    "unicode": "1f40d",
+    "unicode": "1F40D",
     "unicode_alternates": [],
     "name": "snake",
     "shortname": ":snake:",
@@ -4710,7 +4710,7 @@
     ]
   },
   "turtle": {
-    "unicode": "1f422",
+    "unicode": "1F422",
     "unicode_alternates": [],
     "name": "turtle",
     "shortname": ":turtle:",
@@ -4731,7 +4731,7 @@
     ]
   },
   "frog": {
-    "unicode": "1f438",
+    "unicode": "1F438",
     "unicode_alternates": [],
     "name": "frog face",
     "shortname": ":frog:",
@@ -4745,7 +4745,7 @@
     ]
   },
   "whale2": {
-    "unicode": "1f40b",
+    "unicode": "1F40B",
     "unicode_alternates": [],
     "name": "whale",
     "shortname": ":whale2:",
@@ -4766,7 +4766,7 @@
     ]
   },
   "whale": {
-    "unicode": "1f433",
+    "unicode": "1F433",
     "unicode_alternates": [],
     "name": "spouting whale",
     "shortname": ":whale:",
@@ -4782,7 +4782,7 @@
     ]
   },
   "dolphin": {
-    "unicode": "1f42c",
+    "unicode": "1F42C",
     "unicode_alternates": [],
     "name": "dolphin",
     "shortname": ":dolphin:",
@@ -4801,7 +4801,7 @@
     ]
   },
   "octopus": {
-    "unicode": "1f419",
+    "unicode": "1F419",
     "unicode_alternates": [],
     "name": "octopus",
     "shortname": ":octopus:",
@@ -4817,7 +4817,7 @@
     ]
   },
   "fish": {
-    "unicode": "1f41f",
+    "unicode": "1F41F",
     "unicode_alternates": [],
     "name": "fish",
     "shortname": ":fish:",
@@ -4832,7 +4832,7 @@
     ]
   },
   "tropical_fish": {
-    "unicode": "1f420",
+    "unicode": "1F420",
     "unicode_alternates": [],
     "name": "tropical fish",
     "shortname": ":tropical_fish:",
@@ -4846,7 +4846,7 @@
     ]
   },
   "blowfish": {
-    "unicode": "1f421",
+    "unicode": "1F421",
     "unicode_alternates": [],
     "name": "blowfish",
     "shortname": ":blowfish:",
@@ -4866,7 +4866,7 @@
     ]
   },
   "shell": {
-    "unicode": "1f41a",
+    "unicode": "1F41A",
     "unicode_alternates": [],
     "name": "spiral shell",
     "shortname": ":shell:",
@@ -4885,7 +4885,7 @@
     ]
   },
   "snail": {
-    "unicode": "1f40c",
+    "unicode": "1F40C",
     "unicode_alternates": [],
     "name": "snail",
     "shortname": ":snail:",
@@ -4904,7 +4904,7 @@
     ]
   },
   "bug": {
-    "unicode": "1f41b",
+    "unicode": "1F41B",
     "unicode_alternates": [],
     "name": "bug",
     "shortname": ":bug:",
@@ -4921,7 +4921,7 @@
     ]
   },
   "ant": {
-    "unicode": "1f41c",
+    "unicode": "1F41C",
     "unicode_alternates": [],
     "name": "ant",
     "shortname": ":ant:",
@@ -4937,7 +4937,7 @@
     ]
   },
   "bee": {
-    "unicode": "1f41d",
+    "unicode": "1F41D",
     "unicode_alternates": [],
     "name": "honeybee",
     "shortname": ":bee:",
@@ -4960,7 +4960,7 @@
     ]
   },
   "beetle": {
-    "unicode": "1f41e",
+    "unicode": "1F41E",
     "unicode_alternates": [],
     "name": "lady beetle",
     "shortname": ":beetle:",
@@ -4980,7 +4980,7 @@
     ]
   },
   "spider": {
-    "unicode": "1f577",
+    "unicode": "1F577",
     "unicode_alternates": [],
     "name": "spider",
     "shortname": ":spider:",
@@ -4994,7 +4994,7 @@
     ]
   },
   "spider_web": {
-    "unicode": "1f578",
+    "unicode": "1F578",
     "unicode_alternates": [],
     "name": "spider web",
     "shortname": ":spider_web:",
@@ -5007,7 +5007,7 @@
     ]
   },
   "feet": {
-    "unicode": "1f43e",
+    "unicode": "1F43E",
     "unicode_alternates": [],
     "name": "paw prints",
     "shortname": ":feet:",
@@ -5032,7 +5032,7 @@
     ]
   },
   "zap": {
-    "unicode": "26a1",
+    "unicode": "26A1",
     "unicode_alternates": [
       "26A1-FE0F"
     ],
@@ -5050,7 +5050,7 @@
     ]
   },
   "fire": {
-    "unicode": "1f525",
+    "unicode": "1F525",
     "unicode_alternates": [],
     "name": "fire",
     "shortname": ":fire:",
@@ -5067,7 +5067,7 @@
     ]
   },
   "crescent_moon": {
-    "unicode": "1f319",
+    "unicode": "1F319",
     "unicode_alternates": [],
     "name": "crescent moon",
     "shortname": ":crescent_moon:",
@@ -5102,7 +5102,7 @@
     ]
   },
   "partly_sunny": {
-    "unicode": "26c5",
+    "unicode": "26C5",
     "unicode_alternates": [
       "26C5-FE0F"
     ],
@@ -5137,7 +5137,7 @@
     ]
   },
   "cloud_rain": {
-    "unicode": "1f327",
+    "unicode": "1F327",
     "unicode_alternates": [],
     "name": "cloud with rain",
     "shortname": ":cloud_rain:",
@@ -5153,7 +5153,7 @@
     ]
   },
   "cloud_snow": {
-    "unicode": "1f328",
+    "unicode": "1F328",
     "unicode_alternates": [],
     "name": "cloud with snow",
     "shortname": ":cloud_snow:",
@@ -5169,7 +5169,7 @@
     ]
   },
   "cloud_lightning": {
-    "unicode": "1f329",
+    "unicode": "1F329",
     "unicode_alternates": [],
     "name": "cloud with lightning",
     "shortname": ":cloud_lightning:",
@@ -5185,7 +5185,7 @@
     ]
   },
   "cloud_tornado": {
-    "unicode": "1f32a",
+    "unicode": "1F32A",
     "unicode_alternates": [],
     "name": "cloud with tornado",
     "shortname": ":cloud_tornado:",
@@ -5202,7 +5202,7 @@
     ]
   },
   "droplet": {
-    "unicode": "1f4a7",
+    "unicode": "1F4A7",
     "unicode_alternates": [],
     "name": "droplet",
     "shortname": ":droplet:",
@@ -5227,7 +5227,7 @@
     ]
   },
   "sweat_drops": {
-    "unicode": "1f4a6",
+    "unicode": "1F4A6",
     "unicode_alternates": [],
     "name": "splashing sweat symbol",
     "shortname": ":sweat_drops:",
@@ -5257,7 +5257,7 @@
     ]
   },
   "fog": {
-    "unicode": "1f32b",
+    "unicode": "1F32B",
     "unicode_alternates": [],
     "name": "fog",
     "shortname": ":fog:",
@@ -5273,7 +5273,7 @@
     ]
   },
   "dash": {
-    "unicode": "1f4a8",
+    "unicode": "1F4A8",
     "unicode_alternates": [],
     "name": "dash symbol",
     "shortname": ":dash:",
@@ -5319,7 +5319,7 @@
     ]
   },
   "star2": {
-    "unicode": "1f31f",
+    "unicode": "1F31F",
     "unicode_alternates": [],
     "name": "glowing star",
     "shortname": ":star2:",
@@ -5337,7 +5337,7 @@
     ]
   },
   "star": {
-    "unicode": "2b50",
+    "unicode": "2B50",
     "unicode_alternates": [
       "2B50-FE0F"
     ],
@@ -5353,7 +5353,7 @@
     ]
   },
   "stars": {
-    "unicode": "1f320",
+    "unicode": "1F320",
     "unicode_alternates": [],
     "name": "shooting star",
     "shortname": ":stars:",
@@ -5370,7 +5370,7 @@
     ]
   },
   "sunrise_over_mountains": {
-    "unicode": "1f304",
+    "unicode": "1F304",
     "unicode_alternates": [],
     "name": "sunrise over mountains",
     "shortname": ":sunrise_over_mountains:",
@@ -5389,7 +5389,7 @@
     ]
   },
   "sunrise": {
-    "unicode": "1f305",
+    "unicode": "1F305",
     "unicode_alternates": [],
     "name": "sunrise",
     "shortname": ":sunrise:",
@@ -5408,7 +5408,7 @@
     ]
   },
   "rainbow": {
-    "unicode": "1f308",
+    "unicode": "1F308",
     "unicode_alternates": [],
     "name": "rainbow",
     "shortname": ":rainbow:",
@@ -5431,7 +5431,7 @@
     ]
   },
   "ocean": {
-    "unicode": "1f30a",
+    "unicode": "1F30A",
     "unicode_alternates": [],
     "name": "water wave",
     "shortname": ":ocean:",
@@ -5448,7 +5448,7 @@
     ]
   },
   "volcano": {
-    "unicode": "1f30b",
+    "unicode": "1F30B",
     "unicode_alternates": [],
     "name": "volcano",
     "shortname": ":volcano:",
@@ -5466,7 +5466,7 @@
     ]
   },
   "milky_way": {
-    "unicode": "1f30c",
+    "unicode": "1F30C",
     "unicode_alternates": [],
     "name": "milky way",
     "shortname": ":milky_way:",
@@ -5484,7 +5484,7 @@
     ]
   },
   "mount_fuji": {
-    "unicode": "1f5fb",
+    "unicode": "1F5FB",
     "unicode_alternates": [],
     "name": "mount fuji",
     "shortname": ":mount_fuji:",
@@ -5500,7 +5500,7 @@
     ]
   },
   "japan": {
-    "unicode": "1f5fe",
+    "unicode": "1F5FE",
     "unicode_alternates": [],
     "name": "silhouette of japan",
     "shortname": ":japan:",
@@ -5514,7 +5514,7 @@
     ]
   },
   "globe_with_meridians": {
-    "unicode": "1f310",
+    "unicode": "1F310",
     "unicode_alternates": [],
     "name": "globe with meridians",
     "shortname": ":globe_with_meridians:",
@@ -5531,7 +5531,7 @@
     ]
   },
   "earth_africa": {
-    "unicode": "1f30d",
+    "unicode": "1F30D",
     "unicode_alternates": [],
     "name": "earth globe europe-africa",
     "shortname": ":earth_africa:",
@@ -5550,7 +5550,7 @@
     ]
   },
   "earth_americas": {
-    "unicode": "1f30e",
+    "unicode": "1F30E",
     "unicode_alternates": [],
     "name": "earth globe americas",
     "shortname": ":earth_americas:",
@@ -5570,7 +5570,7 @@
     ]
   },
   "earth_asia": {
-    "unicode": "1f30f",
+    "unicode": "1F30F",
     "unicode_alternates": [],
     "name": "earth globe asia-australia",
     "shortname": ":earth_asia:",
@@ -5590,7 +5590,7 @@
     ]
   },
   "new_moon": {
-    "unicode": "1f311",
+    "unicode": "1F311",
     "unicode_alternates": [],
     "name": "new moon symbol",
     "shortname": ":new_moon:",
@@ -5607,7 +5607,7 @@
     ]
   },
   "waxing_crescent_moon": {
-    "unicode": "1f312",
+    "unicode": "1F312",
     "unicode_alternates": [],
     "name": "waxing crescent moon symbol",
     "shortname": ":waxing_crescent_moon:",
@@ -5624,7 +5624,7 @@
     ]
   },
   "first_quarter_moon": {
-    "unicode": "1f313",
+    "unicode": "1F313",
     "unicode_alternates": [],
     "name": "first quarter moon symbol",
     "shortname": ":first_quarter_moon:",
@@ -5641,7 +5641,7 @@
     ]
   },
   "waxing_gibbous_moon": {
-    "unicode": "1f314",
+    "unicode": "1F314",
     "unicode_alternates": [],
     "name": "waxing gibbous moon symbol",
     "shortname": ":waxing_gibbous_moon:",
@@ -5658,7 +5658,7 @@
     ]
   },
   "full_moon": {
-    "unicode": "1f315",
+    "unicode": "1F315",
     "unicode_alternates": [],
     "name": "full moon symbol",
     "shortname": ":full_moon:",
@@ -5679,7 +5679,7 @@
     ]
   },
   "waning_gibbous_moon": {
-    "unicode": "1f316",
+    "unicode": "1F316",
     "unicode_alternates": [],
     "name": "waning gibbous moon symbol",
     "shortname": ":waning_gibbous_moon:",
@@ -5696,7 +5696,7 @@
     ]
   },
   "last_quarter_moon": {
-    "unicode": "1f317",
+    "unicode": "1F317",
     "unicode_alternates": [],
     "name": "last quarter moon symbol",
     "shortname": ":last_quarter_moon:",
@@ -5713,7 +5713,7 @@
     ]
   },
   "waning_crescent_moon": {
-    "unicode": "1f318",
+    "unicode": "1F318",
     "unicode_alternates": [],
     "name": "waning crescent moon symbol",
     "shortname": ":waning_crescent_moon:",
@@ -5730,7 +5730,7 @@
     ]
   },
   "new_moon_with_face": {
-    "unicode": "1f31a",
+    "unicode": "1F31A",
     "unicode_alternates": [],
     "name": "new moon with face",
     "shortname": ":new_moon_with_face:",
@@ -5748,7 +5748,7 @@
     ]
   },
   "full_moon_with_face": {
-    "unicode": "1f31d",
+    "unicode": "1F31D",
     "unicode_alternates": [],
     "name": "full moon with face",
     "shortname": ":full_moon_with_face:",
@@ -5768,7 +5768,7 @@
     ]
   },
   "first_quarter_moon_with_face": {
-    "unicode": "1f31b",
+    "unicode": "1F31B",
     "unicode_alternates": [],
     "name": "first quarter moon with face",
     "shortname": ":first_quarter_moon_with_face:",
@@ -5787,7 +5787,7 @@
     ]
   },
   "last_quarter_moon_with_face": {
-    "unicode": "1f31c",
+    "unicode": "1F31C",
     "unicode_alternates": [],
     "name": "last quarter moon with face",
     "shortname": ":last_quarter_moon_with_face:",
@@ -5806,7 +5806,7 @@
     ]
   },
   "sun_with_face": {
-    "unicode": "1f31e",
+    "unicode": "1F31E",
     "unicode_alternates": [],
     "name": "sun with face",
     "shortname": ":sun_with_face:",
@@ -5823,7 +5823,7 @@
     ]
   },
   "wind_blowing_face": {
-    "unicode": "1f32c",
+    "unicode": "1F32C",
     "unicode_alternates": [],
     "name": "wind blowing face",
     "shortname": ":wind_blowing_face:",
@@ -5837,7 +5837,7 @@
     ]
   },
   "ribbon": {
-    "unicode": "1f380",
+    "unicode": "1F380",
     "unicode_alternates": [],
     "name": "ribbon",
     "shortname": ":ribbon:",
@@ -5855,7 +5855,7 @@
     ]
   },
   "gift": {
-    "unicode": "1f381",
+    "unicode": "1F381",
     "unicode_alternates": [],
     "name": "wrapped present",
     "shortname": ":gift:",
@@ -5873,7 +5873,7 @@
     ]
   },
   "birthday": {
-    "unicode": "1f382",
+    "unicode": "1F382",
     "unicode_alternates": [],
     "name": "birthday cake",
     "shortname": ":birthday:",
@@ -5890,7 +5890,7 @@
     ]
   },
   "jack_o_lantern": {
-    "unicode": "1f383",
+    "unicode": "1F383",
     "unicode_alternates": [],
     "name": "jack-o-lantern",
     "shortname": ":jack_o_lantern:",
@@ -5916,7 +5916,7 @@
     ]
   },
   "christmas_tree": {
-    "unicode": "1f384",
+    "unicode": "1F384",
     "unicode_alternates": [],
     "name": "christmas tree",
     "shortname": ":christmas_tree:",
@@ -5941,7 +5941,7 @@
     ]
   },
   "tanabata_tree": {
-    "unicode": "1f38b",
+    "unicode": "1F38B",
     "unicode_alternates": [],
     "name": "tanabata tree",
     "shortname": ":tanabata_tree:",
@@ -5959,7 +5959,7 @@
     ]
   },
   "bamboo": {
-    "unicode": "1f38d",
+    "unicode": "1F38D",
     "unicode_alternates": [],
     "name": "pine decoration",
     "shortname": ":bamboo:",
@@ -5986,7 +5986,7 @@
     ]
   },
   "rice_scene": {
-    "unicode": "1f391",
+    "unicode": "1F391",
     "unicode_alternates": [],
     "name": "moon viewing ceremony",
     "shortname": ":rice_scene:",
@@ -6005,7 +6005,7 @@
     ]
   },
   "fireworks": {
-    "unicode": "1f386",
+    "unicode": "1F386",
     "unicode_alternates": [],
     "name": "fireworks",
     "shortname": ":fireworks:",
@@ -6029,7 +6029,7 @@
     ]
   },
   "sparkler": {
-    "unicode": "1f387",
+    "unicode": "1F387",
     "unicode_alternates": [],
     "name": "firework sparkler",
     "shortname": ":sparkler:",
@@ -6044,7 +6044,7 @@
     ]
   },
   "tada": {
-    "unicode": "1f389",
+    "unicode": "1F389",
     "unicode_alternates": [],
     "name": "party popper",
     "shortname": ":tada:",
@@ -6062,7 +6062,7 @@
     ]
   },
   "confetti_ball": {
-    "unicode": "1f38a",
+    "unicode": "1F38A",
     "unicode_alternates": [],
     "name": "confetti ball",
     "shortname": ":confetti_ball:",
@@ -6082,7 +6082,7 @@
     ]
   },
   "balloon": {
-    "unicode": "1f388",
+    "unicode": "1F388",
     "unicode_alternates": [],
     "name": "balloon",
     "shortname": ":balloon:",
@@ -6101,7 +6101,7 @@
     ]
   },
   "dizzy": {
-    "unicode": "1f4ab",
+    "unicode": "1F4AB",
     "unicode_alternates": [],
     "name": "dizzy symbol",
     "shortname": ":dizzy:",
@@ -6138,7 +6138,7 @@
     ]
   },
   "boom": {
-    "unicode": "1f4a5",
+    "unicode": "1F4A5",
     "unicode_alternates": [],
     "name": "collision symbol",
     "shortname": ":boom:",
@@ -6159,7 +6159,7 @@
     ]
   },
   "mortar_board": {
-    "unicode": "1f393",
+    "unicode": "1F393",
     "unicode_alternates": [],
     "name": "graduation cap",
     "shortname": ":mortar_board:",
@@ -6181,7 +6181,7 @@
     ]
   },
   "crown": {
-    "unicode": "1f451",
+    "unicode": "1F451",
     "unicode_alternates": [],
     "name": "crown",
     "shortname": ":crown:",
@@ -6197,7 +6197,7 @@
     ]
   },
   "reminder_ribbon": {
-    "unicode": "1f397",
+    "unicode": "1F397",
     "unicode_alternates": [],
     "name": "reminder ribbon",
     "shortname": ":reminder_ribbon:",
@@ -6210,7 +6210,7 @@
     ]
   },
   "military_medal": {
-    "unicode": "1f396",
+    "unicode": "1F396",
     "unicode_alternates": [],
     "name": "military medal",
     "shortname": ":military_medal:",
@@ -6227,7 +6227,7 @@
     ]
   },
   "dolls": {
-    "unicode": "1f38e",
+    "unicode": "1F38E",
     "unicode_alternates": [],
     "name": "japanese dolls",
     "shortname": ":dolls:",
@@ -6251,7 +6251,7 @@
     ]
   },
   "flags": {
-    "unicode": "1f38f",
+    "unicode": "1F38F",
     "unicode_alternates": [],
     "name": "carp streamer",
     "shortname": ":flags:",
@@ -6274,7 +6274,7 @@
     ]
   },
   "wind_chime": {
-    "unicode": "1f390",
+    "unicode": "1F390",
     "unicode_alternates": [],
     "name": "wind chime",
     "shortname": ":wind_chime:",
@@ -6297,7 +6297,7 @@
     ]
   },
   "crossed_flags": {
-    "unicode": "1f38c",
+    "unicode": "1F38C",
     "unicode_alternates": [],
     "name": "crossed flags",
     "shortname": ":crossed_flags:",
@@ -6310,7 +6310,7 @@
     ]
   },
   "izakaya_lantern": {
-    "unicode": "1f3ee",
+    "unicode": "1F3EE",
     "unicode_alternates": [],
     "name": "izakaya lantern",
     "shortname": ":izakaya_lantern:",
@@ -6329,7 +6329,7 @@
     ]
   },
   "ring": {
-    "unicode": "1f48d",
+    "unicode": "1F48D",
     "unicode_alternates": [],
     "name": "ring",
     "shortname": ":ring:",
@@ -6347,7 +6347,7 @@
     ]
   },
   "bouquet2": {
-    "unicode": "1f395",
+    "unicode": "1F395",
     "unicode_alternates": [],
     "name": "bouquet of flowers",
     "shortname": ":bouquet2:",
@@ -6393,7 +6393,7 @@
     ]
   },
   "broken_heart": {
-    "unicode": "1f494",
+    "unicode": "1F494",
     "unicode_alternates": [],
     "name": "broken heart",
     "shortname": ":broken_heart:",
@@ -6411,7 +6411,7 @@
     ]
   },
   "love_letter": {
-    "unicode": "1f48c",
+    "unicode": "1F48C",
     "unicode_alternates": [],
     "name": "love letter",
     "shortname": ":love_letter:",
@@ -6430,7 +6430,7 @@
     ]
   },
   "two_hearts": {
-    "unicode": "1f495",
+    "unicode": "1F495",
     "unicode_alternates": [],
     "name": "two hearts",
     "shortname": ":two_hearts:",
@@ -6447,7 +6447,7 @@
     ]
   },
   "revolving_hearts": {
-    "unicode": "1f49e",
+    "unicode": "1F49E",
     "unicode_alternates": [],
     "name": "revolving hearts",
     "shortname": ":revolving_hearts:",
@@ -6464,7 +6464,7 @@
     ]
   },
   "heartbeat": {
-    "unicode": "1f493",
+    "unicode": "1F493",
     "unicode_alternates": [],
     "name": "beating heart",
     "shortname": ":heartbeat:",
@@ -6480,7 +6480,7 @@
     ]
   },
   "heartpulse": {
-    "unicode": "1f497",
+    "unicode": "1F497",
     "unicode_alternates": [],
     "name": "growing heart",
     "shortname": ":heartpulse:",
@@ -6496,7 +6496,7 @@
     ]
   },
   "sparkling_heart": {
-    "unicode": "1f496",
+    "unicode": "1F496",
     "unicode_alternates": [],
     "name": "sparkling heart",
     "shortname": ":sparkling_heart:",
@@ -6512,7 +6512,7 @@
     ]
   },
   "cupid": {
-    "unicode": "1f498",
+    "unicode": "1F498",
     "unicode_alternates": [],
     "name": "heart with arrow",
     "shortname": ":cupid:",
@@ -6528,7 +6528,7 @@
     ]
   },
   "gift_heart": {
-    "unicode": "1f49d",
+    "unicode": "1F49D",
     "unicode_alternates": [],
     "name": "heart with ribbon",
     "shortname": ":gift_heart:",
@@ -6543,7 +6543,7 @@
     ]
   },
   "heart_tip": {
-    "unicode": "1f394",
+    "unicode": "1F394",
     "unicode_alternates": [],
     "name": "heart with tip on the left",
     "shortname": ":heart_tip:",
@@ -6561,7 +6561,7 @@
     ]
   },
   "heart_decoration": {
-    "unicode": "1f49f",
+    "unicode": "1F49F",
     "unicode_alternates": [],
     "name": "heart decoration",
     "shortname": ":heart_decoration:",
@@ -6576,7 +6576,7 @@
     ]
   },
   "purple_heart": {
-    "unicode": "1f49c",
+    "unicode": "1F49C",
     "unicode_alternates": [],
     "name": "purple heart",
     "shortname": ":purple_heart:",
@@ -6603,7 +6603,7 @@
     ]
   },
   "yellow_heart": {
-    "unicode": "1f49b",
+    "unicode": "1F49B",
     "unicode_alternates": [],
     "name": "yellow heart",
     "shortname": ":yellow_heart:",
@@ -6629,7 +6629,7 @@
     ]
   },
   "green_heart": {
-    "unicode": "1f49a",
+    "unicode": "1F49A",
     "unicode_alternates": [],
     "name": "green heart",
     "shortname": ":green_heart:",
@@ -6652,7 +6652,7 @@
     ]
   },
   "blue_heart": {
-    "unicode": "1f499",
+    "unicode": "1F499",
     "unicode_alternates": [],
     "name": "blue heart",
     "shortname": ":blue_heart:",
@@ -6672,7 +6672,7 @@
     ]
   },
   "runner": {
-    "unicode": "1f3c3",
+    "unicode": "1F3C3",
     "unicode_alternates": [],
     "name": "runner",
     "shortname": ":runner:",
@@ -6692,7 +6692,7 @@
     ]
   },
   "walking": {
-    "unicode": "1f6b6",
+    "unicode": "1F6B6",
     "unicode_alternates": [],
     "name": "pedestrian",
     "shortname": ":walking:",
@@ -6710,7 +6710,7 @@
     ]
   },
   "dancer": {
-    "unicode": "1f483",
+    "unicode": "1F483",
     "unicode_alternates": [],
     "name": "dancer",
     "shortname": ":dancer:",
@@ -6735,7 +6735,7 @@
     ]
   },
   "lifter": {
-    "unicode": "1f3cb",
+    "unicode": "1F3CB",
     "unicode_alternates": [],
     "name": "weight lifter",
     "shortname": ":lifter:",
@@ -6753,7 +6753,7 @@
     ]
   },
   "golfer": {
-    "unicode": "1f3cc",
+    "unicode": "1F3CC",
     "unicode_alternates": [],
     "name": "golfer",
     "shortname": ":golfer:",
@@ -6770,7 +6770,7 @@
     ]
   },
   "rowboat": {
-    "unicode": "1f6a3",
+    "unicode": "1F6A3",
     "unicode_alternates": [],
     "name": "rowboat",
     "shortname": ":rowboat:",
@@ -6789,7 +6789,7 @@
     ]
   },
   "swimmer": {
-    "unicode": "1f3ca",
+    "unicode": "1F3CA",
     "unicode_alternates": [],
     "name": "swimmer",
     "shortname": ":swimmer:",
@@ -6810,7 +6810,7 @@
     ]
   },
   "surfer": {
-    "unicode": "1f3c4",
+    "unicode": "1F3C4",
     "unicode_alternates": [],
     "name": "surfer",
     "shortname": ":surfer:",
@@ -6830,7 +6830,7 @@
     ]
   },
   "bath": {
-    "unicode": "1f6c0",
+    "unicode": "1F6C0",
     "unicode_alternates": [],
     "name": "bath",
     "shortname": ":bath:",
@@ -6854,7 +6854,7 @@
     ]
   },
   "snowboarder": {
-    "unicode": "1f3c2",
+    "unicode": "1F3C2",
     "unicode_alternates": [],
     "name": "snowboarder",
     "shortname": ":snowboarder:",
@@ -6875,7 +6875,7 @@
     ]
   },
   "ski": {
-    "unicode": "1f3bf",
+    "unicode": "1F3BF",
     "unicode_alternates": [],
     "name": "ski and ski boot",
     "shortname": ":ski:",
@@ -6899,7 +6899,7 @@
     ]
   },
   "snowman": {
-    "unicode": "26c4",
+    "unicode": "26C4",
     "unicode_alternates": [
       "26C4-FE0F"
     ],
@@ -6919,7 +6919,7 @@
     ]
   },
   "bicyclist": {
-    "unicode": "1f6b4",
+    "unicode": "1F6B4",
     "unicode_alternates": [],
     "name": "bicyclist",
     "shortname": ":bicyclist:",
@@ -6939,7 +6939,7 @@
     ]
   },
   "mountain_bicyclist": {
-    "unicode": "1f6b5",
+    "unicode": "1F6B5",
     "unicode_alternates": [],
     "name": "mountain bicyclist",
     "shortname": ":mountain_bicyclist:",
@@ -6957,7 +6957,7 @@
     ]
   },
   "motorcycle": {
-    "unicode": "1f3cd",
+    "unicode": "1F3CD",
     "unicode_alternates": [],
     "name": "racing motorcycle",
     "shortname": ":motorcycle:",
@@ -6973,7 +6973,7 @@
     ]
   },
   "race_car": {
-    "unicode": "1f3ce",
+    "unicode": "1F3CE",
     "unicode_alternates": [],
     "name": "racing car",
     "shortname": ":race_car:",
@@ -6993,7 +6993,7 @@
     ]
   },
   "horse_racing": {
-    "unicode": "1f3c7",
+    "unicode": "1F3C7",
     "unicode_alternates": [],
     "name": "horse racing",
     "shortname": ":horse_racing:",
@@ -7011,7 +7011,7 @@
     ]
   },
   "tent": {
-    "unicode": "26fa",
+    "unicode": "26FA",
     "unicode_alternates": [
       "26FA-FE0F"
     ],
@@ -7028,7 +7028,7 @@
     ]
   },
   "fishing_pole_and_fish": {
-    "unicode": "1f3a3",
+    "unicode": "1F3A3",
     "unicode_alternates": [],
     "name": "fishing pole and fish",
     "shortname": ":fishing_pole_and_fish:",
@@ -7044,7 +7044,7 @@
     ]
   },
   "soccer": {
-    "unicode": "26bd",
+    "unicode": "26BD",
     "unicode_alternates": [
       "26BD-FE0F"
     ],
@@ -7062,7 +7062,7 @@
     ]
   },
   "basketball": {
-    "unicode": "1f3c0",
+    "unicode": "1F3C0",
     "unicode_alternates": [],
     "name": "basketball and hoop",
     "shortname": ":basketball:",
@@ -7083,7 +7083,7 @@
     ]
   },
   "football": {
-    "unicode": "1f3c8",
+    "unicode": "1F3C8",
     "unicode_alternates": [],
     "name": "american football",
     "shortname": ":football:",
@@ -7099,7 +7099,7 @@
     ]
   },
   "baseball": {
-    "unicode": "26be",
+    "unicode": "26BE",
     "unicode_alternates": [
       "26BE-FE0F"
     ],
@@ -7117,7 +7117,7 @@
     ]
   },
   "tennis": {
-    "unicode": "1f3be",
+    "unicode": "1F3BE",
     "unicode_alternates": [],
     "name": "tennis racquet and ball",
     "shortname": ":tennis:",
@@ -7137,7 +7137,7 @@
     ]
   },
   "rugby_football": {
-    "unicode": "1f3c9",
+    "unicode": "1F3C9",
     "unicode_alternates": [],
     "name": "rugby football",
     "shortname": ":rugby_football:",
@@ -7156,7 +7156,7 @@
     ]
   },
   "golf": {
-    "unicode": "26f3",
+    "unicode": "26F3",
     "unicode_alternates": [
       "26F3-FE0F"
     ],
@@ -7173,7 +7173,7 @@
     ]
   },
   "trophy": {
-    "unicode": "1f3c6",
+    "unicode": "1F3C6",
     "unicode_alternates": [],
     "name": "trophy",
     "shortname": ":trophy:",
@@ -7196,7 +7196,7 @@
     ]
   },
   "medal": {
-    "unicode": "1f3c5",
+    "unicode": "1F3C5",
     "unicode_alternates": [],
     "name": "sports medal",
     "shortname": ":medal:",
@@ -7220,7 +7220,7 @@
     ]
   },
   "running_shirt_with_sash": {
-    "unicode": "1f3bd",
+    "unicode": "1F3BD",
     "unicode_alternates": [],
     "name": "running shirt with sash",
     "shortname": ":running_shirt_with_sash:",
@@ -7238,7 +7238,7 @@
     ]
   },
   "checkered_flag": {
-    "unicode": "1f3c1",
+    "unicode": "1F3C1",
     "unicode_alternates": [],
     "name": "chequered flag",
     "shortname": ":checkered_flag:",
@@ -7259,7 +7259,7 @@
     ]
   },
   "musical_keyboard": {
-    "unicode": "1f3b9",
+    "unicode": "1F3B9",
     "unicode_alternates": [],
     "name": "musical keyboard",
     "shortname": ":musical_keyboard:",
@@ -7277,7 +7277,7 @@
     ]
   },
   "guitar": {
-    "unicode": "1f3b8",
+    "unicode": "1F3B8",
     "unicode_alternates": [],
     "name": "guitar",
     "shortname": ":guitar:",
@@ -7296,7 +7296,7 @@
     ]
   },
   "violin": {
-    "unicode": "1f3bb",
+    "unicode": "1F3BB",
     "unicode_alternates": [],
     "name": "violin",
     "shortname": ":violin:",
@@ -7312,7 +7312,7 @@
     ]
   },
   "saxophone": {
-    "unicode": "1f3b7",
+    "unicode": "1F3B7",
     "unicode_alternates": [],
     "name": "saxophone",
     "shortname": ":saxophone:",
@@ -7328,7 +7328,7 @@
     ]
   },
   "trumpet": {
-    "unicode": "1f3ba",
+    "unicode": "1F3BA",
     "unicode_alternates": [],
     "name": "trumpet",
     "shortname": ":trumpet:",
@@ -7343,7 +7343,7 @@
     ]
   },
   "musical_note": {
-    "unicode": "1f3b5",
+    "unicode": "1F3B5",
     "unicode_alternates": [],
     "name": "musical note",
     "shortname": ":musical_note:",
@@ -7359,7 +7359,7 @@
     ]
   },
   "notes": {
-    "unicode": "1f3b6",
+    "unicode": "1F3B6",
     "unicode_alternates": [],
     "name": "multiple musical notes",
     "shortname": ":notes:",
@@ -7376,7 +7376,7 @@
     ]
   },
   "musical_score": {
-    "unicode": "1f3bc",
+    "unicode": "1F3BC",
     "unicode_alternates": [],
     "name": "musical score",
     "shortname": ":musical_score:",
@@ -7395,7 +7395,7 @@
     ]
   },
   "headphones": {
-    "unicode": "1f3a7",
+    "unicode": "1F3A7",
     "unicode_alternates": [],
     "name": "headphone",
     "shortname": ":headphones:",
@@ -7416,7 +7416,7 @@
     ]
   },
   "microphone": {
-    "unicode": "1f3a4",
+    "unicode": "1F3A4",
     "unicode_alternates": [],
     "name": "microphone",
     "shortname": ":microphone:",
@@ -7435,7 +7435,7 @@
     ]
   },
   "performing_arts": {
-    "unicode": "1f3ad",
+    "unicode": "1F3AD",
     "unicode_alternates": [],
     "name": "performing arts",
     "shortname": ":performing_arts:",
@@ -7456,7 +7456,7 @@
     ]
   },
   "ticket": {
-    "unicode": "1f3ab",
+    "unicode": "1F3AB",
     "unicode_alternates": [],
     "name": "ticket",
     "shortname": ":ticket:",
@@ -7477,7 +7477,7 @@
     ]
   },
   "tophat": {
-    "unicode": "1f3a9",
+    "unicode": "1F3A9",
     "unicode_alternates": [],
     "name": "top hat",
     "shortname": ":tophat:",
@@ -7503,7 +7503,7 @@
     ]
   },
   "circus_tent": {
-    "unicode": "1f3aa",
+    "unicode": "1F3AA",
     "unicode_alternates": [],
     "name": "circus tent",
     "shortname": ":circus_tent:",
@@ -7522,7 +7522,7 @@
     ]
   },
   "clapper": {
-    "unicode": "1f3ac",
+    "unicode": "1F3AC",
     "unicode_alternates": [],
     "name": "clapper board",
     "shortname": ":clapper:",
@@ -7539,7 +7539,7 @@
     ]
   },
   "film_frames": {
-    "unicode": "1f39e",
+    "unicode": "1F39E",
     "unicode_alternates": [],
     "name": "film frames",
     "shortname": ":film_frames:",
@@ -7557,7 +7557,7 @@
     ]
   },
   "tickets": {
-    "unicode": "1f39f",
+    "unicode": "1F39F",
     "unicode_alternates": [],
     "name": "admission tickets",
     "shortname": ":tickets:",
@@ -7579,7 +7579,7 @@
     ]
   },
   "art": {
-    "unicode": "1f3a8",
+    "unicode": "1F3A8",
     "unicode_alternates": [],
     "name": "artist palette",
     "shortname": ":art:",
@@ -7600,7 +7600,7 @@
     ]
   },
   "dart": {
-    "unicode": "1f3af",
+    "unicode": "1F3AF",
     "unicode_alternates": [],
     "name": "direct hit",
     "shortname": ":dart:",
@@ -7620,7 +7620,7 @@
     ]
   },
   "8ball": {
-    "unicode": "1f3b1",
+    "unicode": "1F3B1",
     "unicode_alternates": [],
     "name": "billiards",
     "shortname": ":8ball:",
@@ -7636,7 +7636,7 @@
     ]
   },
   "bowling": {
-    "unicode": "1f3b3",
+    "unicode": "1F3B3",
     "unicode_alternates": [],
     "name": "bowling",
     "shortname": ":bowling:",
@@ -7657,7 +7657,7 @@
     ]
   },
   "slot_machine": {
-    "unicode": "1f3b0",
+    "unicode": "1F3B0",
     "unicode_alternates": [],
     "name": "slot machine",
     "shortname": ":slot_machine:",
@@ -7675,7 +7675,7 @@
     ]
   },
   "game_die": {
-    "unicode": "1f3b2",
+    "unicode": "1F3B2",
     "unicode_alternates": [],
     "name": "game die",
     "shortname": ":game_die:",
@@ -7691,7 +7691,7 @@
     ]
   },
   "video_game": {
-    "unicode": "1f3ae",
+    "unicode": "1F3AE",
     "unicode_alternates": [],
     "name": "video game",
     "shortname": ":video_game:",
@@ -7710,7 +7710,7 @@
     ]
   },
   "flower_playing_cards": {
-    "unicode": "1f3b4",
+    "unicode": "1F3B4",
     "unicode_alternates": [],
     "name": "flower playing cards",
     "shortname": ":flower_playing_cards:",
@@ -7726,7 +7726,7 @@
     ]
   },
   "black_joker": {
-    "unicode": "1f0cf",
+    "unicode": "1F0CF",
     "unicode_alternates": [],
     "name": "playing card black joker",
     "shortname": ":black_joker:",
@@ -7741,7 +7741,7 @@
     ]
   },
   "mahjong": {
-    "unicode": "1f004",
+    "unicode": "1F004",
     "unicode_alternates": [
       "1F004-FE0F"
     ],
@@ -7758,7 +7758,7 @@
     ]
   },
   "carousel_horse": {
-    "unicode": "1f3a0",
+    "unicode": "1F3A0",
     "unicode_alternates": [],
     "name": "carousel horse",
     "shortname": ":carousel_horse:",
@@ -7776,7 +7776,7 @@
     ]
   },
   "ferris_wheel": {
-    "unicode": "1f3a1",
+    "unicode": "1F3A1",
     "unicode_alternates": [],
     "name": "ferris wheel",
     "shortname": ":ferris_wheel:",
@@ -7796,7 +7796,7 @@
     ]
   },
   "roller_coaster": {
-    "unicode": "1f3a2",
+    "unicode": "1F3A2",
     "unicode_alternates": [],
     "name": "roller coaster",
     "shortname": ":roller_coaster:",
@@ -7816,7 +7816,7 @@
     ]
   },
   "tomato": {
-    "unicode": "1f345",
+    "unicode": "1F345",
     "unicode_alternates": [],
     "name": "tomato",
     "shortname": ":tomato:",
@@ -7834,7 +7834,7 @@
     ]
   },
   "eggplant": {
-    "unicode": "1f346",
+    "unicode": "1F346",
     "unicode_alternates": [],
     "name": "aubergine",
     "shortname": ":eggplant:",
@@ -7852,7 +7852,7 @@
     ]
   },
   "corn": {
-    "unicode": "1f33d",
+    "unicode": "1F33D",
     "unicode_alternates": [],
     "name": "ear of maize",
     "shortname": ":corn:",
@@ -7875,7 +7875,7 @@
     ]
   },
   "sweet_potato": {
-    "unicode": "1f360",
+    "unicode": "1F360",
     "unicode_alternates": [],
     "name": "roasted sweet potato",
     "shortname": ":sweet_potato:",
@@ -7891,7 +7891,7 @@
     ]
   },
   "hot_pepper": {
-    "unicode": "1f336",
+    "unicode": "1F336",
     "unicode_alternates": [],
     "name": "hot pepper",
     "shortname": ":hot_pepper:",
@@ -7910,7 +7910,7 @@
     ]
   },
   "grapes": {
-    "unicode": "1f347",
+    "unicode": "1F347",
     "unicode_alternates": [],
     "name": "grapes",
     "shortname": ":grapes:",
@@ -7927,7 +7927,7 @@
     ]
   },
   "melon": {
-    "unicode": "1f348",
+    "unicode": "1F348",
     "unicode_alternates": [],
     "name": "melon",
     "shortname": ":melon:",
@@ -7944,7 +7944,7 @@
     ]
   },
   "watermelon": {
-    "unicode": "1f349",
+    "unicode": "1F349",
     "unicode_alternates": [],
     "name": "watermelon",
     "shortname": ":watermelon:",
@@ -7961,7 +7961,7 @@
     ]
   },
   "tangerine": {
-    "unicode": "1f34a",
+    "unicode": "1F34A",
     "unicode_alternates": [],
     "name": "tangerine",
     "shortname": ":tangerine:",
@@ -7978,7 +7978,7 @@
     ]
   },
   "lemon": {
-    "unicode": "1f34b",
+    "unicode": "1F34B",
     "unicode_alternates": [],
     "name": "lemon",
     "shortname": ":lemon:",
@@ -7994,7 +7994,7 @@
     ]
   },
   "banana": {
-    "unicode": "1f34c",
+    "unicode": "1F34C",
     "unicode_alternates": [],
     "name": "banana",
     "shortname": ":banana:",
@@ -8010,7 +8010,7 @@
     ]
   },
   "pineapple": {
-    "unicode": "1f34d",
+    "unicode": "1F34D",
     "unicode_alternates": [],
     "name": "pineapple",
     "shortname": ":pineapple:",
@@ -8028,7 +8028,7 @@
     ]
   },
   "apple": {
-    "unicode": "1f34e",
+    "unicode": "1F34E",
     "unicode_alternates": [],
     "name": "red apple",
     "shortname": ":apple:",
@@ -8048,7 +8048,7 @@
     ]
   },
   "green_apple": {
-    "unicode": "1f34f",
+    "unicode": "1F34F",
     "unicode_alternates": [],
     "name": "green apple",
     "shortname": ":green_apple:",
@@ -8067,7 +8067,7 @@
     ]
   },
   "pear": {
-    "unicode": "1f350",
+    "unicode": "1F350",
     "unicode_alternates": [],
     "name": "pear",
     "shortname": ":pear:",
@@ -8082,7 +8082,7 @@
     ]
   },
   "peach": {
-    "unicode": "1f351",
+    "unicode": "1F351",
     "unicode_alternates": [],
     "name": "peach",
     "shortname": ":peach:",
@@ -8099,7 +8099,7 @@
     ]
   },
   "cherries": {
-    "unicode": "1f352",
+    "unicode": "1F352",
     "unicode_alternates": [],
     "name": "cherries",
     "shortname": ":cherries:",
@@ -8116,7 +8116,7 @@
     ]
   },
   "strawberry": {
-    "unicode": "1f353",
+    "unicode": "1F353",
     "unicode_alternates": [],
     "name": "strawberry",
     "shortname": ":strawberry:",
@@ -8133,7 +8133,7 @@
     ]
   },
   "hamburger": {
-    "unicode": "1f354",
+    "unicode": "1F354",
     "unicode_alternates": [],
     "name": "hamburger",
     "shortname": ":hamburger:",
@@ -8151,7 +8151,7 @@
     ]
   },
   "pizza": {
-    "unicode": "1f355",
+    "unicode": "1F355",
     "unicode_alternates": [],
     "name": "slice of pizza",
     "shortname": ":pizza:",
@@ -8170,7 +8170,7 @@
     ]
   },
   "meat_on_bone": {
-    "unicode": "1f356",
+    "unicode": "1F356",
     "unicode_alternates": [],
     "name": "meat on bone",
     "shortname": ":meat_on_bone:",
@@ -8186,7 +8186,7 @@
     ]
   },
   "poultry_leg": {
-    "unicode": "1f357",
+    "unicode": "1F357",
     "unicode_alternates": [],
     "name": "poultry leg",
     "shortname": ":poultry_leg:",
@@ -8202,7 +8202,7 @@
     ]
   },
   "rice_cracker": {
-    "unicode": "1f358",
+    "unicode": "1F358",
     "unicode_alternates": [],
     "name": "rice cracker",
     "shortname": ":rice_cracker:",
@@ -8217,7 +8217,7 @@
     ]
   },
   "rice_ball": {
-    "unicode": "1f359",
+    "unicode": "1F359",
     "unicode_alternates": [],
     "name": "rice ball",
     "shortname": ":rice_ball:",
@@ -8234,7 +8234,7 @@
     ]
   },
   "rice": {
-    "unicode": "1f35a",
+    "unicode": "1F35A",
     "unicode_alternates": [],
     "name": "cooked rice",
     "shortname": ":rice:",
@@ -8250,7 +8250,7 @@
     ]
   },
   "curry": {
-    "unicode": "1f35b",
+    "unicode": "1F35B",
     "unicode_alternates": [],
     "name": "curry and rice",
     "shortname": ":curry:",
@@ -8269,7 +8269,7 @@
     ]
   },
   "ramen": {
-    "unicode": "1f35c",
+    "unicode": "1F35C",
     "unicode_alternates": [],
     "name": "steaming bowl",
     "shortname": ":ramen:",
@@ -8288,7 +8288,7 @@
     ]
   },
   "spaghetti": {
-    "unicode": "1f35d",
+    "unicode": "1F35D",
     "unicode_alternates": [],
     "name": "spaghetti",
     "shortname": ":spaghetti:",
@@ -8306,7 +8306,7 @@
     ]
   },
   "bread": {
-    "unicode": "1f35e",
+    "unicode": "1F35E",
     "unicode_alternates": [],
     "name": "bread",
     "shortname": ":bread:",
@@ -8323,7 +8323,7 @@
     ]
   },
   "fries": {
-    "unicode": "1f35f",
+    "unicode": "1F35F",
     "unicode_alternates": [],
     "name": "french fries",
     "shortname": ":fries:",
@@ -8341,7 +8341,7 @@
     ]
   },
   "dango": {
-    "unicode": "1f361",
+    "unicode": "1F361",
     "unicode_alternates": [],
     "name": "dango",
     "shortname": ":dango:",
@@ -8359,7 +8359,7 @@
     ]
   },
   "oden": {
-    "unicode": "1f362",
+    "unicode": "1F362",
     "unicode_alternates": [],
     "name": "oden",
     "shortname": ":oden:",
@@ -8376,7 +8376,7 @@
     ]
   },
   "sushi": {
-    "unicode": "1f363",
+    "unicode": "1F363",
     "unicode_alternates": [],
     "name": "sushi",
     "shortname": ":sushi:",
@@ -8393,7 +8393,7 @@
     ]
   },
   "fried_shrimp": {
-    "unicode": "1f364",
+    "unicode": "1F364",
     "unicode_alternates": [],
     "name": "fried shrimp",
     "shortname": ":fried_shrimp:",
@@ -8410,7 +8410,7 @@
     ]
   },
   "fish_cake": {
-    "unicode": "1f365",
+    "unicode": "1F365",
     "unicode_alternates": [],
     "name": "fish cake with swirl design",
     "shortname": ":fish_cake:",
@@ -8427,7 +8427,7 @@
     ]
   },
   "icecream": {
-    "unicode": "1f366",
+    "unicode": "1F366",
     "unicode_alternates": [],
     "name": "soft ice cream",
     "shortname": ":icecream:",
@@ -8448,7 +8448,7 @@
     ]
   },
   "shaved_ice": {
-    "unicode": "1f367",
+    "unicode": "1F367",
     "unicode_alternates": [],
     "name": "shaved ice",
     "shortname": ":shaved_ice:",
@@ -8465,7 +8465,7 @@
     ]
   },
   "ice_cream": {
-    "unicode": "1f368",
+    "unicode": "1F368",
     "unicode_alternates": [],
     "name": "ice cream",
     "shortname": ":ice_cream:",
@@ -8487,7 +8487,7 @@
     ]
   },
   "doughnut": {
-    "unicode": "1f369",
+    "unicode": "1F369",
     "unicode_alternates": [],
     "name": "doughnut",
     "shortname": ":doughnut:",
@@ -8511,7 +8511,7 @@
     ]
   },
   "cookie": {
-    "unicode": "1f36a",
+    "unicode": "1F36A",
     "unicode_alternates": [],
     "name": "cookie",
     "shortname": ":cookie:",
@@ -8531,7 +8531,7 @@
     ]
   },
   "chocolate_bar": {
-    "unicode": "1f36b",
+    "unicode": "1F36B",
     "unicode_alternates": [],
     "name": "chocolate bar",
     "shortname": ":chocolate_bar:",
@@ -8549,7 +8549,7 @@
     ]
   },
   "candy": {
-    "unicode": "1f36c",
+    "unicode": "1F36C",
     "unicode_alternates": [],
     "name": "candy",
     "shortname": ":candy:",
@@ -8566,7 +8566,7 @@
     ]
   },
   "lollipop": {
-    "unicode": "1f36d",
+    "unicode": "1F36D",
     "unicode_alternates": [],
     "name": "lollipop",
     "shortname": ":lollipop:",
@@ -8585,7 +8585,7 @@
     ]
   },
   "custard": {
-    "unicode": "1f36e",
+    "unicode": "1F36E",
     "unicode_alternates": [],
     "name": "custard",
     "shortname": ":custard:",
@@ -8606,7 +8606,7 @@
     ]
   },
   "honey_pot": {
-    "unicode": "1f36f",
+    "unicode": "1F36F",
     "unicode_alternates": [],
     "name": "honey pot",
     "shortname": ":honey_pot:",
@@ -8622,7 +8622,7 @@
     ]
   },
   "cake": {
-    "unicode": "1f370",
+    "unicode": "1F370",
     "unicode_alternates": [],
     "name": "shortcake",
     "shortname": ":cake:",
@@ -8640,7 +8640,7 @@
     ]
   },
   "bento": {
-    "unicode": "1f371",
+    "unicode": "1F371",
     "unicode_alternates": [],
     "name": "bento box",
     "shortname": ":bento:",
@@ -8659,7 +8659,7 @@
     ]
   },
   "stew": {
-    "unicode": "1f372",
+    "unicode": "1F372",
     "unicode_alternates": [],
     "name": "pot of food",
     "shortname": ":stew:",
@@ -8677,7 +8677,7 @@
     ]
   },
   "egg": {
-    "unicode": "1f373",
+    "unicode": "1F373",
     "unicode_alternates": [],
     "name": "cooking",
     "shortname": ":egg:",
@@ -8698,7 +8698,7 @@
     ]
   },
   "fork_and_knife": {
-    "unicode": "1f374",
+    "unicode": "1F374",
     "unicode_alternates": [],
     "name": "fork and knife",
     "shortname": ":fork_and_knife:",
@@ -8717,7 +8717,7 @@
     ]
   },
   "tea": {
-    "unicode": "1f375",
+    "unicode": "1F375",
     "unicode_alternates": [],
     "name": "teacup without handle",
     "shortname": ":tea:",
@@ -8757,7 +8757,7 @@
     ]
   },
   "sake": {
-    "unicode": "1f376",
+    "unicode": "1F376",
     "unicode_alternates": [],
     "name": "sake bottle and cup",
     "shortname": ":sake:",
@@ -8777,7 +8777,7 @@
     ]
   },
   "wine_glass": {
-    "unicode": "1f377",
+    "unicode": "1F377",
     "unicode_alternates": [],
     "name": "wine glass",
     "shortname": ":wine_glass:",
@@ -8799,7 +8799,7 @@
     ]
   },
   "cocktail": {
-    "unicode": "1f378",
+    "unicode": "1F378",
     "unicode_alternates": [],
     "name": "cocktail glass",
     "shortname": ":cocktail:",
@@ -8818,7 +8818,7 @@
     ]
   },
   "tropical_drink": {
-    "unicode": "1f379",
+    "unicode": "1F379",
     "unicode_alternates": [],
     "name": "tropical drink",
     "shortname": ":tropical_drink:",
@@ -8837,7 +8837,7 @@
     ]
   },
   "beer": {
-    "unicode": "1f37a",
+    "unicode": "1F37A",
     "unicode_alternates": [],
     "name": "beer mug",
     "shortname": ":beer:",
@@ -8865,7 +8865,7 @@
     ]
   },
   "beers": {
-    "unicode": "1f37b",
+    "unicode": "1F37B",
     "unicode_alternates": [],
     "name": "clinking beer mugs",
     "shortname": ":beers:",
@@ -8889,7 +8889,7 @@
     ]
   },
   "baby_bottle": {
-    "unicode": "1f37c",
+    "unicode": "1F37C",
     "unicode_alternates": [],
     "name": "baby bottle",
     "shortname": ":baby_bottle:",
@@ -8908,7 +8908,7 @@
     ]
   },
   "watch": {
-    "unicode": "231a",
+    "unicode": "231A",
     "unicode_alternates": [
       "231A-FE0F"
     ],
@@ -8925,7 +8925,7 @@
     ]
   },
   "iphone": {
-    "unicode": "1f4f1",
+    "unicode": "1F4F1",
     "unicode_alternates": [],
     "name": "mobile phone",
     "shortname": ":iphone:",
@@ -8944,7 +8944,7 @@
     ]
   },
   "calling": {
-    "unicode": "1f4f2",
+    "unicode": "1F4F2",
     "unicode_alternates": [],
     "name": "mobile phone with rightwards arrow at left",
     "shortname": ":calling:",
@@ -8959,7 +8959,7 @@
     ]
   },
   "computer": {
-    "unicode": "1f4bb",
+    "unicode": "1F4BB",
     "unicode_alternates": [],
     "name": "personal computer",
     "shortname": ":computer:",
@@ -8973,7 +8973,7 @@
     ]
   },
   "desktop": {
-    "unicode": "1f5a5",
+    "unicode": "1F5A5",
     "unicode_alternates": [],
     "name": "desktop computer",
     "shortname": ":desktop:",
@@ -8988,7 +8988,7 @@
     ]
   },
   "computer_old": {
-    "unicode": "1f5b3",
+    "unicode": "1F5B3",
     "unicode_alternates": [],
     "name": "old personal computer",
     "shortname": ":computer_old:",
@@ -9004,7 +9004,7 @@
     ]
   },
   "keyboard": {
-    "unicode": "1f5ae",
+    "unicode": "1F5AE",
     "unicode_alternates": [],
     "name": "wired keyboard",
     "shortname": ":keyboard:",
@@ -9022,7 +9022,7 @@
     ]
   },
   "mouse_one": {
-    "unicode": "1f5af",
+    "unicode": "1F5AF",
     "unicode_alternates": [],
     "name": "one button mouse",
     "shortname": ":mouse_one:",
@@ -9039,7 +9039,7 @@
     ]
   },
   "trackball": {
-    "unicode": "1f5b2",
+    "unicode": "1F5B2",
     "unicode_alternates": [],
     "name": "trackball",
     "shortname": ":trackball:",
@@ -9054,7 +9054,7 @@
     ]
   },
   "keyboard_mouse": {
-    "unicode": "1f5a6",
+    "unicode": "1F5A6",
     "unicode_alternates": [],
     "name": "keyboard and mouse",
     "shortname": ":keyboard_mouse:",
@@ -9071,7 +9071,7 @@
     ]
   },
   "network": {
-    "unicode": "1f5a7",
+    "unicode": "1F5A7",
     "unicode_alternates": [],
     "name": "three networked computers",
     "shortname": ":network:",
@@ -9089,7 +9089,7 @@
     ]
   },
   "printer": {
-    "unicode": "1f5a8",
+    "unicode": "1F5A8",
     "unicode_alternates": [],
     "name": "printer",
     "shortname": ":printer:",
@@ -9105,7 +9105,7 @@
     ]
   },
   "desktop_window": {
-    "unicode": "1f5d4",
+    "unicode": "1F5D4",
     "unicode_alternates": [],
     "name": "desktop window",
     "shortname": ":desktop_window:",
@@ -9118,7 +9118,7 @@
     ]
   },
   "calculator": {
-    "unicode": "1f5a9",
+    "unicode": "1F5A9",
     "unicode_alternates": [],
     "name": "pocket calculator",
     "shortname": ":calculator:",
@@ -9137,7 +9137,7 @@
     ]
   },
   "alarm_clock": {
-    "unicode": "23f0",
+    "unicode": "23F0",
     "unicode_alternates": [],
     "name": "alarm clock",
     "shortname": ":alarm_clock:",
@@ -9151,7 +9151,7 @@
     ]
   },
   "clock": {
-    "unicode": "1f570",
+    "unicode": "1F570",
     "unicode_alternates": [],
     "name": "mantlepiece clock",
     "shortname": ":clock:",
@@ -9166,7 +9166,7 @@
     ]
   },
   "hourglass_flowing_sand": {
-    "unicode": "23f3",
+    "unicode": "23F3",
     "unicode_alternates": [],
     "name": "hourglass with flowing sand",
     "shortname": ":hourglass_flowing_sand:",
@@ -9181,7 +9181,7 @@
     ]
   },
   "hourglass": {
-    "unicode": "231b",
+    "unicode": "231B",
     "unicode_alternates": [
       "231B-FE0F"
     ],
@@ -9198,7 +9198,7 @@
     ]
   },
   "camera": {
-    "unicode": "1f4f7",
+    "unicode": "1F4F7",
     "unicode_alternates": [],
     "name": "camera",
     "shortname": ":camera:",
@@ -9213,7 +9213,7 @@
     ]
   },
   "camera_with_flash": {
-    "unicode": "1f4f8",
+    "unicode": "1F4F8",
     "unicode_alternates": [],
     "name": "camera with flash",
     "shortname": ":camera_with_flash:",
@@ -9227,7 +9227,7 @@
     ]
   },
   "video_camera": {
-    "unicode": "1f4f9",
+    "unicode": "1F4F9",
     "unicode_alternates": [],
     "name": "video camera",
     "shortname": ":video_camera:",
@@ -9242,7 +9242,7 @@
     ]
   },
   "movie_camera": {
-    "unicode": "1f3a5",
+    "unicode": "1F3A5",
     "unicode_alternates": [],
     "name": "movie camera",
     "shortname": ":movie_camera:",
@@ -9259,7 +9259,7 @@
     ]
   },
   "projector": {
-    "unicode": "1f4fd",
+    "unicode": "1F4FD",
     "unicode_alternates": [],
     "name": "film projector",
     "shortname": ":projector:",
@@ -9279,7 +9279,7 @@
     ]
   },
   "tv": {
-    "unicode": "1f4fa",
+    "unicode": "1F4FA",
     "unicode_alternates": [],
     "name": "television",
     "shortname": ":tv:",
@@ -9296,7 +9296,7 @@
     ]
   },
   "keyboard_with_jacks": {
-    "unicode": "1f398",
+    "unicode": "1F398",
     "unicode_alternates": [],
     "name": "musical keyboard with jacks",
     "shortname": ":keyboard_with_jacks:",
@@ -9313,7 +9313,7 @@
     ]
   },
   "microphone2": {
-    "unicode": "1f399",
+    "unicode": "1F399",
     "unicode_alternates": [],
     "name": "studio microphone",
     "shortname": ":microphone2:",
@@ -9330,7 +9330,7 @@
     ]
   },
   "level_slider": {
-    "unicode": "1f39a",
+    "unicode": "1F39A",
     "unicode_alternates": [],
     "name": "level slider",
     "shortname": ":level_slider:",
@@ -9343,7 +9343,7 @@
     ]
   },
   "control_knobs": {
-    "unicode": "1f39b",
+    "unicode": "1F39B",
     "unicode_alternates": [],
     "name": "control knobs",
     "shortname": ":control_knobs:",
@@ -9356,7 +9356,7 @@
     ]
   },
   "radio": {
-    "unicode": "1f4fb",
+    "unicode": "1F4FB",
     "unicode_alternates": [],
     "name": "radio",
     "shortname": ":radio:",
@@ -9372,7 +9372,7 @@
     ]
   },
   "stereo": {
-    "unicode": "1f4fe",
+    "unicode": "1F4FE",
     "unicode_alternates": [],
     "name": "portable stereo",
     "shortname": ":stereo:",
@@ -9391,7 +9391,7 @@
     ]
   },
   "pager": {
-    "unicode": "1f4df",
+    "unicode": "1F4DF",
     "unicode_alternates": [],
     "name": "pager",
     "shortname": ":pager:",
@@ -9405,7 +9405,7 @@
     ]
   },
   "joystick": {
-    "unicode": "1f579",
+    "unicode": "1F579",
     "unicode_alternates": [],
     "name": "joystick",
     "shortname": ":joystick:",
@@ -9420,7 +9420,7 @@
     ]
   },
   "telephone_receiver": {
-    "unicode": "1f4de",
+    "unicode": "1F4DE",
     "unicode_alternates": [],
     "name": "telephone receiver",
     "shortname": ":telephone_receiver:",
@@ -9436,7 +9436,7 @@
     ]
   },
   "left_receiver": {
-    "unicode": "1f57b",
+    "unicode": "1F57B",
     "unicode_alternates": [],
     "name": "left hand telephone receiver",
     "shortname": ":left_receiver:",
@@ -9453,7 +9453,7 @@
     ]
   },
   "telephone": {
-    "unicode": "260e",
+    "unicode": "260E",
     "unicode_alternates": [
       "260E-FE0F"
     ],
@@ -9471,7 +9471,7 @@
     ]
   },
   "telephone_white": {
-    "unicode": "1f57e",
+    "unicode": "1F57E",
     "unicode_alternates": [],
     "name": "white touchtone telephone",
     "shortname": ":telephone_white:",
@@ -9488,7 +9488,7 @@
     ]
   },
   "telephone_black": {
-    "unicode": "1f57f",
+    "unicode": "1F57F",
     "unicode_alternates": [],
     "name": "black touchtone telephone",
     "shortname": ":telephone_black:",
@@ -9505,7 +9505,7 @@
     ]
   },
   "flip_phone": {
-    "unicode": "1f581",
+    "unicode": "1F581",
     "unicode_alternates": [],
     "name": "clamshell mobile phone",
     "shortname": ":flip_phone:",
@@ -9520,7 +9520,7 @@
     ]
   },
   "fax": {
-    "unicode": "1f4e0",
+    "unicode": "1F4E0",
     "unicode_alternates": [],
     "name": "fax machine",
     "shortname": ":fax:",
@@ -9534,7 +9534,7 @@
     ]
   },
   "minidisc": {
-    "unicode": "1f4bd",
+    "unicode": "1F4BD",
     "unicode_alternates": [],
     "name": "minidisc",
     "shortname": ":minidisc:",
@@ -9551,7 +9551,7 @@
     ]
   },
   "floppy_disk": {
-    "unicode": "1f4be",
+    "unicode": "1F4BE",
     "unicode_alternates": [],
     "name": "floppy disk",
     "shortname": ":floppy_disk:",
@@ -9571,7 +9571,7 @@
     ]
   },
   "floppy_black": {
-    "unicode": "1f5aa",
+    "unicode": "1F5AA",
     "unicode_alternates": [],
     "name": "black hard shell floppy disk",
     "shortname": ":floppy_black:",
@@ -9593,7 +9593,7 @@
     ]
   },
   "floppy_white": {
-    "unicode": "1f5ab",
+    "unicode": "1F5AB",
     "unicode_alternates": [],
     "name": "white hard shell floppy disk",
     "shortname": ":floppy_white:",
@@ -9615,7 +9615,7 @@
     ]
   },
   "cartridge": {
-    "unicode": "1f5ad",
+    "unicode": "1F5AD",
     "unicode_alternates": [],
     "name": "tape cartridge",
     "shortname": ":cartridge:",
@@ -9638,7 +9638,7 @@
     ]
   },
   "hard_disk": {
-    "unicode": "1f5b4",
+    "unicode": "1F5B4",
     "unicode_alternates": [],
     "name": "hard disk",
     "shortname": ":hard_disk:",
@@ -9659,7 +9659,7 @@
     ]
   },
   "cd": {
-    "unicode": "1f4bf",
+    "unicode": "1F4BF",
     "unicode_alternates": [],
     "name": "optical disc",
     "shortname": ":cd:",
@@ -9675,7 +9675,7 @@
     ]
   },
   "dvd": {
-    "unicode": "1f4c0",
+    "unicode": "1F4C0",
     "unicode_alternates": [],
     "name": "dvd",
     "shortname": ":dvd:",
@@ -9691,7 +9691,7 @@
     ]
   },
   "optical_disk": {
-    "unicode": "1f5b8",
+    "unicode": "1F5B8",
     "unicode_alternates": [],
     "name": "optical disc icon",
     "shortname": ":optical_disk:",
@@ -9710,7 +9710,7 @@
     ]
   },
   "vhs": {
-    "unicode": "1f4fc",
+    "unicode": "1F4FC",
     "unicode_alternates": [],
     "name": "videocassette",
     "shortname": ":vhs:",
@@ -9725,7 +9725,7 @@
     ]
   },
   "battery": {
-    "unicode": "1f50b",
+    "unicode": "1F50B",
     "unicode_alternates": [],
     "name": "battery",
     "shortname": ":battery:",
@@ -9740,7 +9740,7 @@
     ]
   },
   "electric_plug": {
-    "unicode": "1f50c",
+    "unicode": "1F50C",
     "unicode_alternates": [],
     "name": "electric plug",
     "shortname": ":electric_plug:",
@@ -9754,7 +9754,7 @@
     ]
   },
   "bulb": {
-    "unicode": "1f4a1",
+    "unicode": "1F4A1",
     "unicode_alternates": [],
     "name": "electric light bulb",
     "shortname": ":bulb:",
@@ -9768,7 +9768,7 @@
     ]
   },
   "flashlight": {
-    "unicode": "1f526",
+    "unicode": "1F526",
     "unicode_alternates": [],
     "name": "electric torch",
     "shortname": ":flashlight:",
@@ -9782,7 +9782,7 @@
     ]
   },
   "candle": {
-    "unicode": "1f56f",
+    "unicode": "1F56F",
     "unicode_alternates": [],
     "name": "candle",
     "shortname": ":candle:",
@@ -9796,7 +9796,7 @@
     ]
   },
   "satellite": {
-    "unicode": "1f4e1",
+    "unicode": "1F4E1",
     "unicode_alternates": [],
     "name": "satellite antenna",
     "shortname": ":satellite:",
@@ -9809,7 +9809,7 @@
     ]
   },
   "satellite_orbital": {
-    "unicode": "1f6f0",
+    "unicode": "1F6F0",
     "unicode_alternates": [],
     "name": "satellite",
     "shortname": ":satellite_orbital:",
@@ -9824,7 +9824,7 @@
     ]
   },
   "credit_card": {
-    "unicode": "1f4b3",
+    "unicode": "1F4B3",
     "unicode_alternates": [],
     "name": "credit card",
     "shortname": ":credit_card:",
@@ -9849,7 +9849,7 @@
     ]
   },
   "money_with_wings": {
-    "unicode": "1f4b8",
+    "unicode": "1F4B8",
     "unicode_alternates": [],
     "name": "money with wings",
     "shortname": ":money_with_wings:",
@@ -9872,7 +9872,7 @@
     ]
   },
   "moneybag": {
-    "unicode": "1f4b0",
+    "unicode": "1F4B0",
     "unicode_alternates": [],
     "name": "money bag",
     "shortname": ":moneybag:",
@@ -9889,7 +9889,7 @@
     ]
   },
   "gem": {
-    "unicode": "1f48e",
+    "unicode": "1F48E",
     "unicode_alternates": [],
     "name": "gem stone",
     "shortname": ":gem:",
@@ -9904,7 +9904,7 @@
     ]
   },
   "closed_umbrella": {
-    "unicode": "1f302",
+    "unicode": "1F302",
     "unicode_alternates": [],
     "name": "closed umbrella",
     "shortname": ":closed_umbrella:",
@@ -9924,7 +9924,7 @@
     ]
   },
   "pouch": {
-    "unicode": "1f45d",
+    "unicode": "1F45D",
     "unicode_alternates": [],
     "name": "pouch",
     "shortname": ":pouch:",
@@ -9942,7 +9942,7 @@
     ]
   },
   "purse": {
-    "unicode": "1f45b",
+    "unicode": "1F45B",
     "unicode_alternates": [],
     "name": "purse",
     "shortname": ":purse:",
@@ -9964,7 +9964,7 @@
     ]
   },
   "handbag": {
-    "unicode": "1f45c",
+    "unicode": "1F45C",
     "unicode_alternates": [],
     "name": "handbag",
     "shortname": ":handbag:",
@@ -9980,7 +9980,7 @@
     ]
   },
   "briefcase": {
-    "unicode": "1f4bc",
+    "unicode": "1F4BC",
     "unicode_alternates": [],
     "name": "briefcase",
     "shortname": ":briefcase:",
@@ -9995,7 +9995,7 @@
     ]
   },
   "school_satchel": {
-    "unicode": "1f392",
+    "unicode": "1F392",
     "unicode_alternates": [],
     "name": "school satchel",
     "shortname": ":school_satchel:",
@@ -10018,7 +10018,7 @@
     ]
   },
   "lipstick": {
-    "unicode": "1f484",
+    "unicode": "1F484",
     "unicode_alternates": [],
     "name": "lipstick",
     "shortname": ":lipstick:",
@@ -10033,7 +10033,7 @@
     ]
   },
   "eyeglasses": {
-    "unicode": "1f453",
+    "unicode": "1F453",
     "unicode_alternates": [],
     "name": "eyeglasses",
     "shortname": ":eyeglasses:",
@@ -10060,7 +10060,7 @@
     ]
   },
   "dark_sunglasses": {
-    "unicode": "1f576",
+    "unicode": "1F576",
     "unicode_alternates": [],
     "name": "dark sunglasses",
     "shortname": ":dark_sunglasses:",
@@ -10074,7 +10074,7 @@
     ]
   },
   "womans_hat": {
-    "unicode": "1f452",
+    "unicode": "1F452",
     "unicode_alternates": [],
     "name": "womans hat",
     "shortname": ":womans_hat:",
@@ -10089,7 +10089,7 @@
     ]
   },
   "sandal": {
-    "unicode": "1f461",
+    "unicode": "1F461",
     "unicode_alternates": [],
     "name": "womans sandal",
     "shortname": ":sandal:",
@@ -10104,7 +10104,7 @@
     ]
   },
   "high_heel": {
-    "unicode": "1f460",
+    "unicode": "1F460",
     "unicode_alternates": [],
     "name": "high-heeled shoe",
     "shortname": ":high_heel:",
@@ -10119,7 +10119,7 @@
     ]
   },
   "boot": {
-    "unicode": "1f462",
+    "unicode": "1F462",
     "unicode_alternates": [],
     "name": "womans boots",
     "shortname": ":boot:",
@@ -10133,7 +10133,7 @@
     ]
   },
   "mans_shoe": {
-    "unicode": "1f45e",
+    "unicode": "1F45E",
     "unicode_alternates": [],
     "name": "mans shoe",
     "shortname": ":mans_shoe:",
@@ -10147,7 +10147,7 @@
     ]
   },
   "athletic_shoe": {
-    "unicode": "1f45f",
+    "unicode": "1F45F",
     "unicode_alternates": [],
     "name": "athletic shoe",
     "shortname": ":athletic_shoe:",
@@ -10161,7 +10161,7 @@
     ]
   },
   "bikini": {
-    "unicode": "1f459",
+    "unicode": "1F459",
     "unicode_alternates": [],
     "name": "bikini",
     "shortname": ":bikini:",
@@ -10179,7 +10179,7 @@
     ]
   },
   "dress": {
-    "unicode": "1f457",
+    "unicode": "1F457",
     "unicode_alternates": [],
     "name": "dress",
     "shortname": ":dress:",
@@ -10193,7 +10193,7 @@
     ]
   },
   "kimono": {
-    "unicode": "1f458",
+    "unicode": "1F458",
     "unicode_alternates": [],
     "name": "kimono",
     "shortname": ":kimono:",
@@ -10210,7 +10210,7 @@
     ]
   },
   "womans_clothes": {
-    "unicode": "1f45a",
+    "unicode": "1F45A",
     "unicode_alternates": [],
     "name": "womans clothes",
     "shortname": ":womans_clothes:",
@@ -10233,7 +10233,7 @@
     ]
   },
   "shirt": {
-    "unicode": "1f455",
+    "unicode": "1F455",
     "unicode_alternates": [],
     "name": "t-shirt",
     "shortname": ":shirt:",
@@ -10249,7 +10249,7 @@
     ]
   },
   "necktie": {
-    "unicode": "1f454",
+    "unicode": "1F454",
     "unicode_alternates": [],
     "name": "necktie",
     "shortname": ":necktie:",
@@ -10266,7 +10266,7 @@
     ]
   },
   "jeans": {
-    "unicode": "1f456",
+    "unicode": "1F456",
     "unicode_alternates": [],
     "name": "jeans",
     "shortname": ":jeans:",
@@ -10288,7 +10288,7 @@
     ]
   },
   "door": {
-    "unicode": "1f6aa",
+    "unicode": "1F6AA",
     "unicode_alternates": [],
     "name": "door",
     "shortname": ":door:",
@@ -10308,7 +10308,7 @@
     ]
   },
   "shower": {
-    "unicode": "1f6bf",
+    "unicode": "1F6BF",
     "unicode_alternates": [],
     "name": "shower",
     "shortname": ":shower:",
@@ -10328,7 +10328,7 @@
     ]
   },
   "bathtub": {
-    "unicode": "1f6c1",
+    "unicode": "1F6C1",
     "unicode_alternates": [],
     "name": "bathtub",
     "shortname": ":bathtub:",
@@ -10353,7 +10353,7 @@
     ]
   },
   "toilet": {
-    "unicode": "1f6bd",
+    "unicode": "1F6BD",
     "unicode_alternates": [],
     "name": "toilet",
     "shortname": ":toilet:",
@@ -10373,7 +10373,7 @@
     ]
   },
   "barber": {
-    "unicode": "1f488",
+    "unicode": "1F488",
     "unicode_alternates": [],
     "name": "barber pole",
     "shortname": ":barber:",
@@ -10389,7 +10389,7 @@
     ]
   },
   "syringe": {
-    "unicode": "1f489",
+    "unicode": "1F489",
     "unicode_alternates": [],
     "name": "syringe",
     "shortname": ":syringe:",
@@ -10407,7 +10407,7 @@
     ]
   },
   "pill": {
-    "unicode": "1f48a",
+    "unicode": "1F48A",
     "unicode_alternates": [],
     "name": "pill",
     "shortname": ":pill:",
@@ -10423,7 +10423,7 @@
     ]
   },
   "microscope": {
-    "unicode": "1f52c",
+    "unicode": "1F52C",
     "unicode_alternates": [],
     "name": "microscope",
     "shortname": ":microscope:",
@@ -10438,7 +10438,7 @@
     ]
   },
   "telescope": {
-    "unicode": "1f52d",
+    "unicode": "1F52D",
     "unicode_alternates": [],
     "name": "telescope",
     "shortname": ":telescope:",
@@ -10452,7 +10452,7 @@
     ]
   },
   "crystal_ball": {
-    "unicode": "1f52e",
+    "unicode": "1F52E",
     "unicode_alternates": [],
     "name": "crystal ball",
     "shortname": ":crystal_ball:",
@@ -10467,7 +10467,7 @@
     ]
   },
   "wrench": {
-    "unicode": "1f527",
+    "unicode": "1F527",
     "unicode_alternates": [],
     "name": "wrench",
     "shortname": ":wrench:",
@@ -10482,7 +10482,7 @@
     ]
   },
   "knife": {
-    "unicode": "1f52a",
+    "unicode": "1F52A",
     "unicode_alternates": [],
     "name": "hocho",
     "shortname": ":knife:",
@@ -10495,7 +10495,7 @@
     ]
   },
   "dagger": {
-    "unicode": "1f5e1",
+    "unicode": "1F5E1",
     "unicode_alternates": [],
     "name": "dagger knife",
     "shortname": ":dagger:",
@@ -10511,7 +10511,7 @@
     ]
   },
   "nut_and_bolt": {
-    "unicode": "1f529",
+    "unicode": "1F529",
     "unicode_alternates": [],
     "name": "nut and bolt",
     "shortname": ":nut_and_bolt:",
@@ -10524,7 +10524,7 @@
     ]
   },
   "hammer": {
-    "unicode": "1f528",
+    "unicode": "1F528",
     "unicode_alternates": [],
     "name": "hammer",
     "shortname": ":hammer:",
@@ -10542,7 +10542,7 @@
     ]
   },
   "tools": {
-    "unicode": "1f6e0",
+    "unicode": "1F6E0",
     "unicode_alternates": [],
     "name": "hammer and wrench",
     "shortname": ":tools:",
@@ -10557,7 +10557,7 @@
     ]
   },
   "oil": {
-    "unicode": "1f6e2",
+    "unicode": "1F6E2",
     "unicode_alternates": [],
     "name": "oil drum",
     "shortname": ":oil:",
@@ -10572,7 +10572,7 @@
     ]
   },
   "bomb": {
-    "unicode": "1f4a3",
+    "unicode": "1F4A3",
     "unicode_alternates": [],
     "name": "bomb",
     "shortname": ":bomb:",
@@ -10586,7 +10586,7 @@
     ]
   },
   "smoking": {
-    "unicode": "1f6ac",
+    "unicode": "1F6AC",
     "unicode_alternates": [],
     "name": "smoking symbol",
     "shortname": ":smoking:",
@@ -10607,7 +10607,7 @@
     ]
   },
   "crossbones": {
-    "unicode": "1f571",
+    "unicode": "1F571",
     "unicode_alternates": [],
     "name": "black skull and crossbones",
     "shortname": ":crossbones:",
@@ -10624,7 +10624,7 @@
     ]
   },
   "gun": {
-    "unicode": "1f52b",
+    "unicode": "1F52B",
     "unicode_alternates": [],
     "name": "pistol",
     "shortname": ":gun:",
@@ -10639,7 +10639,7 @@
     ]
   },
   "bookmark": {
-    "unicode": "1f516",
+    "unicode": "1F516",
     "unicode_alternates": [],
     "name": "bookmark",
     "shortname": ":bookmark:",
@@ -10652,7 +10652,7 @@
     ]
   },
   "newspaper": {
-    "unicode": "1f4f0",
+    "unicode": "1F4F0",
     "unicode_alternates": [],
     "name": "newspaper",
     "shortname": ":newspaper:",
@@ -10666,7 +10666,7 @@
     ]
   },
   "newspaper2": {
-    "unicode": "1f5de",
+    "unicode": "1F5DE",
     "unicode_alternates": [],
     "name": "rolled-up newspaper",
     "shortname": ":newspaper2:",
@@ -10682,7 +10682,7 @@
     ]
   },
   "thermometer": {
-    "unicode": "1f321",
+    "unicode": "1F321",
     "unicode_alternates": [],
     "name": "thermometer",
     "shortname": ":thermometer:",
@@ -10695,7 +10695,7 @@
     ]
   },
   "label": {
-    "unicode": "1f3f7",
+    "unicode": "1F3F7",
     "unicode_alternates": [],
     "name": "label",
     "shortname": ":label:",
@@ -10708,7 +10708,7 @@
     ]
   },
   "key": {
-    "unicode": "1f511",
+    "unicode": "1F511",
     "unicode_alternates": [],
     "name": "key",
     "shortname": ":key:",
@@ -10723,7 +10723,7 @@
     ]
   },
   "key2": {
-    "unicode": "1f5dd",
+    "unicode": "1F5DD",
     "unicode_alternates": [],
     "name": "old key",
     "shortname": ":key2:",
@@ -10759,7 +10759,7 @@
     ]
   },
   "envelope_back": {
-    "unicode": "1f582",
+    "unicode": "1F582",
     "unicode_alternates": [],
     "name": "back of envelope",
     "shortname": ":envelope_back:",
@@ -10777,7 +10777,7 @@
     ]
   },
   "envelope_stamped": {
-    "unicode": "1f583",
+    "unicode": "1F583",
     "unicode_alternates": [],
     "name": "stamped envelope",
     "shortname": ":envelope_stamped:",
@@ -10795,7 +10795,7 @@
     ]
   },
   "envelope_flying": {
-    "unicode": "1f585",
+    "unicode": "1F585",
     "unicode_alternates": [],
     "name": "flying envelope",
     "shortname": ":envelope_flying:",
@@ -10813,7 +10813,7 @@
     ]
   },
   "envelope_stamped_pen": {
-    "unicode": "1f586",
+    "unicode": "1F586",
     "unicode_alternates": [],
     "name": "pen over stamped envelope",
     "shortname": ":envelope_stamped_pen:",
@@ -10831,7 +10831,7 @@
     ]
   },
   "envelope_with_arrow": {
-    "unicode": "1f4e9",
+    "unicode": "1F4E9",
     "unicode_alternates": [],
     "name": "envelope with downwards arrow above",
     "shortname": ":envelope_with_arrow:",
@@ -10844,7 +10844,7 @@
     ]
   },
   "incoming_envelope": {
-    "unicode": "1f4e8",
+    "unicode": "1F4E8",
     "unicode_alternates": [],
     "name": "incoming envelope",
     "shortname": ":incoming_envelope:",
@@ -10858,7 +10858,7 @@
     ]
   },
   "e-mail": {
-    "unicode": "1f4e7",
+    "unicode": "1F4E7",
     "unicode_alternates": [],
     "name": "e-mail symbol",
     "shortname": ":e-mail:",
@@ -10875,7 +10875,7 @@
     ]
   },
   "inbox_tray": {
-    "unicode": "1f4e5",
+    "unicode": "1F4E5",
     "unicode_alternates": [],
     "name": "inbox tray",
     "shortname": ":inbox_tray:",
@@ -10889,7 +10889,7 @@
     ]
   },
   "outbox_tray": {
-    "unicode": "1f4e4",
+    "unicode": "1F4E4",
     "unicode_alternates": [],
     "name": "outbox tray",
     "shortname": ":outbox_tray:",
@@ -10903,7 +10903,7 @@
     ]
   },
   "package": {
-    "unicode": "1f4e6",
+    "unicode": "1F4E6",
     "unicode_alternates": [],
     "name": "package",
     "shortname": ":package:",
@@ -10917,7 +10917,7 @@
     ]
   },
   "postal_horn": {
-    "unicode": "1f4ef",
+    "unicode": "1F4EF",
     "unicode_alternates": [],
     "name": "postal horn",
     "shortname": ":postal_horn:",
@@ -10931,7 +10931,7 @@
     ]
   },
   "postbox": {
-    "unicode": "1f4ee",
+    "unicode": "1F4EE",
     "unicode_alternates": [],
     "name": "postbox",
     "shortname": ":postbox:",
@@ -10946,7 +10946,7 @@
     ]
   },
   "mailbox_closed": {
-    "unicode": "1f4ea",
+    "unicode": "1F4EA",
     "unicode_alternates": [],
     "name": "closed mailbox with lowered flag",
     "shortname": ":mailbox_closed:",
@@ -10961,7 +10961,7 @@
     ]
   },
   "mailbox": {
-    "unicode": "1f4eb",
+    "unicode": "1F4EB",
     "unicode_alternates": [],
     "name": "closed mailbox with raised flag",
     "shortname": ":mailbox:",
@@ -10976,7 +10976,7 @@
     ]
   },
   "mailbox_with_no_mail": {
-    "unicode": "1f4ed",
+    "unicode": "1F4ED",
     "unicode_alternates": [],
     "name": "open mailbox with lowered flag",
     "shortname": ":mailbox_with_no_mail:",
@@ -10990,7 +10990,7 @@
     ]
   },
   "mailbox_with_mail": {
-    "unicode": "1f4ec",
+    "unicode": "1F4EC",
     "unicode_alternates": [],
     "name": "open mailbox with raised flag",
     "shortname": ":mailbox_with_mail:",
@@ -11005,7 +11005,7 @@
     ]
   },
   "document": {
-    "unicode": "1f5ce",
+    "unicode": "1F5CE",
     "unicode_alternates": [],
     "name": "document",
     "shortname": ":document:",
@@ -11018,7 +11018,7 @@
     ]
   },
   "document_text": {
-    "unicode": "1f5b9",
+    "unicode": "1F5B9",
     "unicode_alternates": [],
     "name": "document with text",
     "shortname": ":document_text:",
@@ -11033,7 +11033,7 @@
     ]
   },
   "page": {
-    "unicode": "1f5cf",
+    "unicode": "1F5CF",
     "unicode_alternates": [],
     "name": "page",
     "shortname": ":page:",
@@ -11046,7 +11046,7 @@
     ]
   },
   "page_facing_up": {
-    "unicode": "1f4c4",
+    "unicode": "1F4C4",
     "unicode_alternates": [],
     "name": "page facing up",
     "shortname": ":page_facing_up:",
@@ -11059,7 +11059,7 @@
     ]
   },
   "page_with_curl": {
-    "unicode": "1f4c3",
+    "unicode": "1F4C3",
     "unicode_alternates": [],
     "name": "page with curl",
     "shortname": ":page_with_curl:",
@@ -11072,7 +11072,7 @@
     ]
   },
   "pages": {
-    "unicode": "1f5d0",
+    "unicode": "1F5D0",
     "unicode_alternates": [],
     "name": "pages",
     "shortname": ":pages:",
@@ -11085,7 +11085,7 @@
     ]
   },
   "bookmark_tabs": {
-    "unicode": "1f4d1",
+    "unicode": "1F4D1",
     "unicode_alternates": [],
     "name": "bookmark tabs",
     "shortname": ":bookmark_tabs:",
@@ -11098,7 +11098,7 @@
     ]
   },
   "wastebasket": {
-    "unicode": "1f5d1",
+    "unicode": "1F5D1",
     "unicode_alternates": [],
     "name": "wastebasket",
     "shortname": ":wastebasket:",
@@ -11113,7 +11113,7 @@
     ]
   },
   "note_empty": {
-    "unicode": "1f5c6",
+    "unicode": "1F5C6",
     "unicode_alternates": [],
     "name": "empty note page",
     "shortname": ":note_empty:",
@@ -11129,7 +11129,7 @@
     ]
   },
   "notepad_empty": {
-    "unicode": "1f5c7",
+    "unicode": "1F5C7",
     "unicode_alternates": [],
     "name": "empty note pad",
     "shortname": ":notepad_empty:",
@@ -11145,7 +11145,7 @@
     ]
   },
   "note": {
-    "unicode": "1f5c9",
+    "unicode": "1F5C9",
     "unicode_alternates": [],
     "name": "note page",
     "shortname": ":note:",
@@ -11161,7 +11161,7 @@
     ]
   },
   "notepad": {
-    "unicode": "1f5ca",
+    "unicode": "1F5CA",
     "unicode_alternates": [],
     "name": "note pad",
     "shortname": ":notepad:",
@@ -11177,7 +11177,7 @@
     ]
   },
   "notepad_spiral": {
-    "unicode": "1f5d2",
+    "unicode": "1F5D2",
     "unicode_alternates": [],
     "name": "spiral note pad",
     "shortname": ":notepad_spiral:",
@@ -11192,7 +11192,7 @@
     ]
   },
   "chart_with_upwards_trend": {
-    "unicode": "1f4c8",
+    "unicode": "1F4C8",
     "unicode_alternates": [],
     "name": "chart with upwards trend",
     "shortname": ":chart_with_upwards_trend:",
@@ -11206,7 +11206,7 @@
     ]
   },
   "chart_with_downwards_trend": {
-    "unicode": "1f4c9",
+    "unicode": "1F4C9",
     "unicode_alternates": [],
     "name": "chart with downwards trend",
     "shortname": ":chart_with_downwards_trend:",
@@ -11220,7 +11220,7 @@
     ]
   },
   "bar_chart": {
-    "unicode": "1f4ca",
+    "unicode": "1F4CA",
     "unicode_alternates": [],
     "name": "bar chart",
     "shortname": ":bar_chart:",
@@ -11235,7 +11235,7 @@
     ]
   },
   "stock_chart": {
-    "unicode": "1f5e0",
+    "unicode": "1F5E0",
     "unicode_alternates": [],
     "name": "stock chart",
     "shortname": ":stock_chart:",
@@ -11251,7 +11251,7 @@
     ]
   },
   "date": {
-    "unicode": "1f4c5",
+    "unicode": "1F4C5",
     "unicode_alternates": [],
     "name": "calendar",
     "shortname": ":date:",
@@ -11266,7 +11266,7 @@
     ]
   },
   "calendar": {
-    "unicode": "1f4c6",
+    "unicode": "1F4C6",
     "unicode_alternates": [],
     "name": "tear-off calendar",
     "shortname": ":calendar:",
@@ -11281,7 +11281,7 @@
     ]
   },
   "calendar_spiral": {
-    "unicode": "1f5d3",
+    "unicode": "1F5D3",
     "unicode_alternates": [],
     "name": "spiral calendar pad",
     "shortname": ":calendar_spiral:",
@@ -11298,7 +11298,7 @@
     ]
   },
   "ballot_box": {
-    "unicode": "1f5f3",
+    "unicode": "1F5F3",
     "unicode_alternates": [],
     "name": "ballot box with ballot",
     "shortname": ":ballot_box:",
@@ -11313,7 +11313,7 @@
     ]
   },
   "low_brightness": {
-    "unicode": "1f505",
+    "unicode": "1F505",
     "unicode_alternates": [],
     "name": "low brightness symbol",
     "shortname": ":low_brightness:",
@@ -11327,7 +11327,7 @@
     ]
   },
   "high_brightness": {
-    "unicode": "1f506",
+    "unicode": "1F506",
     "unicode_alternates": [],
     "name": "high brightness symbol",
     "shortname": ":high_brightness:",
@@ -11342,7 +11342,7 @@
     ]
   },
   "compression": {
-    "unicode": "1f5dc",
+    "unicode": "1F5DC",
     "unicode_alternates": [],
     "name": "compression",
     "shortname": ":compression:",
@@ -11355,7 +11355,7 @@
     ]
   },
   "frame_x": {
-    "unicode": "1f5be",
+    "unicode": "1F5BE",
     "unicode_alternates": [],
     "name": "frame with an x",
     "shortname": ":frame_x:",
@@ -11371,7 +11371,7 @@
     ]
   },
   "frame_photo": {
-    "unicode": "1f5bc",
+    "unicode": "1F5BC",
     "unicode_alternates": [],
     "name": "frame with picture",
     "shortname": ":frame_photo:",
@@ -11386,7 +11386,7 @@
     ]
   },
   "frame_tiles": {
-    "unicode": "1f5bd",
+    "unicode": "1F5BD",
     "unicode_alternates": [],
     "name": "frame with tiles",
     "shortname": ":frame_tiles:",
@@ -11402,7 +11402,7 @@
     ]
   },
   "scroll": {
-    "unicode": "1f4dc",
+    "unicode": "1F4DC",
     "unicode_alternates": [],
     "name": "scroll",
     "shortname": ":scroll:",
@@ -11420,7 +11420,7 @@
     ]
   },
   "clipboard": {
-    "unicode": "1f4cb",
+    "unicode": "1F4CB",
     "unicode_alternates": [],
     "name": "clipboard",
     "shortname": ":clipboard:",
@@ -11434,7 +11434,7 @@
     ]
   },
   "book2": {
-    "unicode": "1f56e",
+    "unicode": "1F56E",
     "unicode_alternates": [],
     "name": "book",
     "shortname": ":book2:",
@@ -11451,7 +11451,7 @@
     ]
   },
   "book": {
-    "unicode": "1f4d6",
+    "unicode": "1F4D6",
     "unicode_alternates": [],
     "name": "open book",
     "shortname": ":book:",
@@ -11468,7 +11468,7 @@
     ]
   },
   "notebook": {
-    "unicode": "1f4d3",
+    "unicode": "1F4D3",
     "unicode_alternates": [],
     "name": "notebook",
     "shortname": ":notebook:",
@@ -11485,7 +11485,7 @@
     ]
   },
   "notebook_with_decorative_cover": {
-    "unicode": "1f4d4",
+    "unicode": "1F4D4",
     "unicode_alternates": [],
     "name": "notebook with decorative cover",
     "shortname": ":notebook_with_decorative_cover:",
@@ -11502,7 +11502,7 @@
     ]
   },
   "ledger": {
-    "unicode": "1f4d2",
+    "unicode": "1F4D2",
     "unicode_alternates": [],
     "name": "ledger",
     "shortname": ":ledger:",
@@ -11519,7 +11519,7 @@
     ]
   },
   "closed_book": {
-    "unicode": "1f4d5",
+    "unicode": "1F4D5",
     "unicode_alternates": [],
     "name": "closed book",
     "shortname": ":closed_book:",
@@ -11535,7 +11535,7 @@
     ]
   },
   "green_book": {
-    "unicode": "1f4d7",
+    "unicode": "1F4D7",
     "unicode_alternates": [],
     "name": "green book",
     "shortname": ":green_book:",
@@ -11551,7 +11551,7 @@
     ]
   },
   "blue_book": {
-    "unicode": "1f4d8",
+    "unicode": "1F4D8",
     "unicode_alternates": [],
     "name": "blue book",
     "shortname": ":blue_book:",
@@ -11567,7 +11567,7 @@
     ]
   },
   "orange_book": {
-    "unicode": "1f4d9",
+    "unicode": "1F4D9",
     "unicode_alternates": [],
     "name": "orange book",
     "shortname": ":orange_book:",
@@ -11583,7 +11583,7 @@
     ]
   },
   "books": {
-    "unicode": "1f4da",
+    "unicode": "1F4DA",
     "unicode_alternates": [],
     "name": "books",
     "shortname": ":books:",
@@ -11601,7 +11601,7 @@
     ]
   },
   "card_index": {
-    "unicode": "1f4c7",
+    "unicode": "1F4C7",
     "unicode_alternates": [],
     "name": "card index",
     "shortname": ":card_index:",
@@ -11616,7 +11616,7 @@
     ]
   },
   "dividers": {
-    "unicode": "1f5c2",
+    "unicode": "1F5C2",
     "unicode_alternates": [],
     "name": "card index dividers",
     "shortname": ":dividers:",
@@ -11632,7 +11632,7 @@
     ]
   },
   "card_box": {
-    "unicode": "1f5c3",
+    "unicode": "1F5C3",
     "unicode_alternates": [],
     "name": "card file box",
     "shortname": ":card_box:",
@@ -11648,7 +11648,7 @@
     ]
   },
   "link": {
-    "unicode": "1f517",
+    "unicode": "1F517",
     "unicode_alternates": [],
     "name": "link symbol",
     "shortname": ":link:",
@@ -11662,7 +11662,7 @@
     ]
   },
   "paperclip": {
-    "unicode": "1f4ce",
+    "unicode": "1F4CE",
     "unicode_alternates": [],
     "name": "paperclip",
     "shortname": ":paperclip:",
@@ -11676,7 +11676,7 @@
     ]
   },
   "paperclips": {
-    "unicode": "1f587",
+    "unicode": "1F587",
     "unicode_alternates": [],
     "name": "linked paperclips",
     "shortname": ":paperclips:",
@@ -11692,7 +11692,7 @@
     ]
   },
   "pushpin": {
-    "unicode": "1f4cc",
+    "unicode": "1F4CC",
     "unicode_alternates": [],
     "name": "pushpin",
     "shortname": ":pushpin:",
@@ -11705,7 +11705,7 @@
     ]
   },
   "pushpin_black": {
-    "unicode": "1f588",
+    "unicode": "1F588",
     "unicode_alternates": [],
     "name": "black pushpin",
     "shortname": ":pushpin_black:",
@@ -11734,7 +11734,7 @@
     ]
   },
   "triangular_ruler": {
-    "unicode": "1f4d0",
+    "unicode": "1F4D0",
     "unicode_alternates": [],
     "name": "triangular ruler",
     "shortname": ":triangular_ruler:",
@@ -11750,7 +11750,7 @@
     ]
   },
   "round_pushpin": {
-    "unicode": "1f4cd",
+    "unicode": "1F4CD",
     "unicode_alternates": [],
     "name": "round pushpin",
     "shortname": ":round_pushpin:",
@@ -11763,7 +11763,7 @@
     ]
   },
   "straight_ruler": {
-    "unicode": "1f4cf",
+    "unicode": "1F4CF",
     "unicode_alternates": [],
     "name": "straight ruler",
     "shortname": ":straight_ruler:",
@@ -11776,7 +11776,7 @@
     ]
   },
   "triangular_flag_on_post": {
-    "unicode": "1f6a9",
+    "unicode": "1F6A9",
     "unicode_alternates": [],
     "name": "triangular flag on post",
     "shortname": ":triangular_flag_on_post:",
@@ -11791,7 +11791,7 @@
     ]
   },
   "pennant_white": {
-    "unicode": "1f3f1",
+    "unicode": "1F3F1",
     "unicode_alternates": [],
     "name": "white pennant",
     "shortname": ":pennant_white:",
@@ -11807,7 +11807,7 @@
     ]
   },
   "pennant_black": {
-    "unicode": "1f3f2",
+    "unicode": "1F3F2",
     "unicode_alternates": [],
     "name": "black pennant",
     "shortname": ":pennant_black:",
@@ -11823,7 +11823,7 @@
     ]
   },
   "flag_white": {
-    "unicode": "1f3f3",
+    "unicode": "1F3F3",
     "unicode_alternates": [],
     "name": "waving white flag",
     "shortname": ":flag_white:",
@@ -11839,7 +11839,7 @@
     ]
   },
   "flag_black": {
-    "unicode": "1f3f4",
+    "unicode": "1F3F4",
     "unicode_alternates": [],
     "name": "waving black flag",
     "shortname": ":flag_black:",
@@ -11855,7 +11855,7 @@
     ]
   },
   "hole": {
-    "unicode": "1f573",
+    "unicode": "1F573",
     "unicode_alternates": [],
     "name": "hole",
     "shortname": ":hole:",
@@ -11869,7 +11869,7 @@
     ]
   },
   "folder": {
-    "unicode": "1f5c0",
+    "unicode": "1F5C0",
     "unicode_alternates": [],
     "name": "folder",
     "shortname": ":folder:",
@@ -11882,7 +11882,7 @@
     ]
   },
   "folder_open": {
-    "unicode": "1f5c1",
+    "unicode": "1F5C1",
     "unicode_alternates": [],
     "name": "open folder",
     "shortname": ":folder_open:",
@@ -11898,7 +11898,7 @@
     ]
   },
   "file_folder": {
-    "unicode": "1f4c1",
+    "unicode": "1F4C1",
     "unicode_alternates": [],
     "name": "file folder",
     "shortname": ":file_folder:",
@@ -11911,7 +11911,7 @@
     ]
   },
   "open_file_folder": {
-    "unicode": "1f4c2",
+    "unicode": "1F4C2",
     "unicode_alternates": [],
     "name": "open file folder",
     "shortname": ":open_file_folder:",
@@ -11925,7 +11925,7 @@
     ]
   },
   "file_cabinet": {
-    "unicode": "1f5c4",
+    "unicode": "1F5C4",
     "unicode_alternates": [],
     "name": "file cabinet",
     "shortname": ":file_cabinet:",
@@ -11957,7 +11957,7 @@
     ]
   },
   "pencil2": {
-    "unicode": "270f",
+    "unicode": "270F",
     "unicode_alternates": [
       "270F-FE0F"
     ],
@@ -11974,7 +11974,7 @@
     ]
   },
   "pencil3": {
-    "unicode": "1f589",
+    "unicode": "1F589",
     "unicode_alternates": [],
     "name": "lower left pencil",
     "shortname": ":pencil3:",
@@ -11991,7 +11991,7 @@
     ]
   },
   "pen_ballpoint": {
-    "unicode": "1f58a",
+    "unicode": "1F58A",
     "unicode_alternates": [],
     "name": "lower left ballpoint pen",
     "shortname": ":pen_ballpoint:",
@@ -12008,7 +12008,7 @@
     ]
   },
   "pen_fountain": {
-    "unicode": "1f58b",
+    "unicode": "1F58B",
     "unicode_alternates": [],
     "name": "lower left fountain pen",
     "shortname": ":pen_fountain:",
@@ -12025,7 +12025,7 @@
     ]
   },
   "paintbrush": {
-    "unicode": "1f58c",
+    "unicode": "1F58C",
     "unicode_alternates": [],
     "name": "lower left paintbrush",
     "shortname": ":paintbrush:",
@@ -12042,7 +12042,7 @@
     ]
   },
   "crayon": {
-    "unicode": "1f58d",
+    "unicode": "1F58D",
     "unicode_alternates": [],
     "name": "lower left crayon",
     "shortname": ":crayon:",
@@ -12060,7 +12060,7 @@
     ]
   },
   "pencil": {
-    "unicode": "1f4dd",
+    "unicode": "1F4DD",
     "unicode_alternates": [],
     "name": "memo",
     "shortname": ":pencil:",
@@ -12077,7 +12077,7 @@
     ]
   },
   "lock_with_ink_pen": {
-    "unicode": "1f50f",
+    "unicode": "1F50F",
     "unicode_alternates": [],
     "name": "lock with ink pen",
     "shortname": ":lock_with_ink_pen:",
@@ -12091,7 +12091,7 @@
     ]
   },
   "closed_lock_with_key": {
-    "unicode": "1f510",
+    "unicode": "1F510",
     "unicode_alternates": [],
     "name": "closed lock with key",
     "shortname": ":closed_lock_with_key:",
@@ -12105,7 +12105,7 @@
     ]
   },
   "lock": {
-    "unicode": "1f512",
+    "unicode": "1F512",
     "unicode_alternates": [],
     "name": "lock",
     "shortname": ":lock:",
@@ -12119,7 +12119,7 @@
     ]
   },
   "unlock": {
-    "unicode": "1f513",
+    "unicode": "1F513",
     "unicode_alternates": [],
     "name": "open lock",
     "shortname": ":unlock:",
@@ -12134,7 +12134,7 @@
     ]
   },
   "mega": {
-    "unicode": "1f4e3",
+    "unicode": "1F4E3",
     "unicode_alternates": [],
     "name": "cheering megaphone",
     "shortname": ":mega:",
@@ -12149,7 +12149,7 @@
     ]
   },
   "loudspeaker": {
-    "unicode": "1f4e2",
+    "unicode": "1F4E2",
     "unicode_alternates": [],
     "name": "public address loudspeaker",
     "shortname": ":loudspeaker:",
@@ -12163,7 +12163,7 @@
     ]
   },
   "speaker": {
-    "unicode": "1f508",
+    "unicode": "1F508",
     "unicode_alternates": [],
     "name": "speaker",
     "shortname": ":speaker:",
@@ -12180,7 +12180,7 @@
     ]
   },
   "sound": {
-    "unicode": "1f509",
+    "unicode": "1F509",
     "unicode_alternates": [],
     "name": "speaker with one sound wave",
     "shortname": ":sound:",
@@ -12194,7 +12194,7 @@
     ]
   },
   "loud_sound": {
-    "unicode": "1f50a",
+    "unicode": "1F50A",
     "unicode_alternates": [],
     "name": "speaker with three sound waves",
     "shortname": ":loud_sound:",
@@ -12209,7 +12209,7 @@
     ]
   },
   "mute": {
-    "unicode": "1f507",
+    "unicode": "1F507",
     "unicode_alternates": [],
     "name": "speaker with cancellation stroke",
     "shortname": ":mute:",
@@ -12224,7 +12224,7 @@
     ]
   },
   "right_speaker": {
-    "unicode": "1f568",
+    "unicode": "1F568",
     "unicode_alternates": [],
     "name": "right speaker",
     "shortname": ":right_speaker:",
@@ -12241,7 +12241,7 @@
     ]
   },
   "right_speaker_one": {
-    "unicode": "1f569",
+    "unicode": "1F569",
     "unicode_alternates": [],
     "name": "right speaker with one sound wave",
     "shortname": ":right_speaker_one:",
@@ -12257,7 +12257,7 @@
     ]
   },
   "right_speaker_three": {
-    "unicode": "1f56a",
+    "unicode": "1F56A",
     "unicode_alternates": [],
     "name": "right speaker with three sound waves",
     "shortname": ":right_speaker_three:",
@@ -12274,7 +12274,7 @@
     ]
   },
   "bullhorn": {
-    "unicode": "1f56b",
+    "unicode": "1F56B",
     "unicode_alternates": [],
     "name": "bullhorn",
     "shortname": ":bullhorn:",
@@ -12290,7 +12290,7 @@
     ]
   },
   "bullhorn_waves": {
-    "unicode": "1f56c",
+    "unicode": "1F56C",
     "unicode_alternates": [],
     "name": "bullhorn with sound waves",
     "shortname": ":bullhorn_waves:",
@@ -12308,7 +12308,7 @@
     ]
   },
   "zzz": {
-    "unicode": "1f4a4",
+    "unicode": "1F4A4",
     "unicode_alternates": [],
     "name": "sleeping symbol",
     "shortname": ":zzz:",
@@ -12323,7 +12323,7 @@
     ]
   },
   "bell": {
-    "unicode": "1f514",
+    "unicode": "1F514",
     "unicode_alternates": [],
     "name": "bell",
     "shortname": ":bell:",
@@ -12341,7 +12341,7 @@
     ]
   },
   "no_bell": {
-    "unicode": "1f515",
+    "unicode": "1F515",
     "unicode_alternates": [],
     "name": "bell with cancellation stroke",
     "shortname": ":no_bell:",
@@ -12357,7 +12357,7 @@
     ]
   },
   "ringing_bell": {
-    "unicode": "1f56d",
+    "unicode": "1F56D",
     "unicode_alternates": [],
     "name": "ringing bell",
     "shortname": ":ringing_bell:",
@@ -12374,7 +12374,7 @@
     ]
   },
   "ascending_notes": {
-    "unicode": "1f39c",
+    "unicode": "1F39C",
     "unicode_alternates": [],
     "name": "beamed ascending musical notes",
     "shortname": ":ascending_notes:",
@@ -12390,7 +12390,7 @@
     ]
   },
   "descending_notes": {
-    "unicode": "1f39d",
+    "unicode": "1F39D",
     "unicode_alternates": [],
     "name": "beamed descending musical notes",
     "shortname": ":descending_notes:",
@@ -12406,7 +12406,7 @@
     ]
   },
   "cross_white": {
-    "unicode": "1f546",
+    "unicode": "1F546",
     "unicode_alternates": [],
     "name": "white latin cross",
     "shortname": ":cross_white:",
@@ -12422,7 +12422,7 @@
     ]
   },
   "cross_heavy": {
-    "unicode": "1f547",
+    "unicode": "1F547",
     "unicode_alternates": [],
     "name": "heavy latin cross",
     "shortname": ":cross_heavy:",
@@ -12438,7 +12438,7 @@
     ]
   },
   "celtic_cross": {
-    "unicode": "1f548",
+    "unicode": "1F548",
     "unicode_alternates": [],
     "name": "celtic cross",
     "shortname": ":celtic_cross:",
@@ -12452,7 +12452,7 @@
     ]
   },
   "om_symbol": {
-    "unicode": "1f549",
+    "unicode": "1F549",
     "unicode_alternates": [],
     "name": "om symbol",
     "shortname": ":om_symbol:",
@@ -12472,7 +12472,7 @@
     ]
   },
   "dove": {
-    "unicode": "1f54a",
+    "unicode": "1F54A",
     "unicode_alternates": [],
     "name": "dove of peace",
     "shortname": ":dove:",
@@ -12488,7 +12488,7 @@
     ]
   },
   "thought_balloon": {
-    "unicode": "1f4ad",
+    "unicode": "1F4AD",
     "unicode_alternates": [],
     "name": "thought balloon",
     "shortname": ":thought_balloon:",
@@ -12506,7 +12506,7 @@
     ]
   },
   "speech_balloon": {
-    "unicode": "1f4ac",
+    "unicode": "1F4AC",
     "unicode_alternates": [],
     "name": "speech balloon",
     "shortname": ":speech_balloon:",
@@ -12525,7 +12525,7 @@
     ]
   },
   "speech_left": {
-    "unicode": "1f5e8",
+    "unicode": "1F5E8",
     "unicode_alternates": [],
     "name": "left speech bubble",
     "shortname": ":speech_left:",
@@ -12546,7 +12546,7 @@
     ]
   },
   "speech_right": {
-    "unicode": "1f5e9",
+    "unicode": "1F5E9",
     "unicode_alternates": [],
     "name": "right speech bubble",
     "shortname": ":speech_right:",
@@ -12567,7 +12567,7 @@
     ]
   },
   "speech_two": {
-    "unicode": "1f5ea",
+    "unicode": "1F5EA",
     "unicode_alternates": [],
     "name": "two speech bubbles",
     "shortname": ":speech_two:",
@@ -12588,7 +12588,7 @@
     ]
   },
   "speech_three": {
-    "unicode": "1f5eb",
+    "unicode": "1F5EB",
     "unicode_alternates": [],
     "name": "three speech bubbles",
     "shortname": ":speech_three:",
@@ -12609,7 +12609,7 @@
     ]
   },
   "thought_left": {
-    "unicode": "1f5ec",
+    "unicode": "1F5EC",
     "unicode_alternates": [],
     "name": "left thought bubble",
     "shortname": ":thought_left:",
@@ -12629,7 +12629,7 @@
     ]
   },
   "thought_right": {
-    "unicode": "1f5ed",
+    "unicode": "1F5ED",
     "unicode_alternates": [],
     "name": "right thought bubble",
     "shortname": ":thought_right:",
@@ -12649,7 +12649,7 @@
     ]
   },
   "anger_left": {
-    "unicode": "1f5ee",
+    "unicode": "1F5EE",
     "unicode_alternates": [],
     "name": "left anger bubble",
     "shortname": ":anger_left:",
@@ -12671,7 +12671,7 @@
     ]
   },
   "anger_right": {
-    "unicode": "1f5ef",
+    "unicode": "1F5EF",
     "unicode_alternates": [],
     "name": "right anger bubble",
     "shortname": ":anger_right:",
@@ -12693,7 +12693,7 @@
     ]
   },
   "mood_bubble": {
-    "unicode": "1f5f0",
+    "unicode": "1F5F0",
     "unicode_alternates": [],
     "name": "mood bubble",
     "shortname": ":mood_bubble:",
@@ -12710,7 +12710,7 @@
     ]
   },
   "mood_bubble_lightning": {
-    "unicode": "1f5f1",
+    "unicode": "1F5F1",
     "unicode_alternates": [],
     "name": "lightning mood bubble",
     "shortname": ":mood_bubble_lightning:",
@@ -12729,7 +12729,7 @@
     ]
   },
   "children_crossing": {
-    "unicode": "1f6b8",
+    "unicode": "1F6B8",
     "unicode_alternates": [],
     "name": "children crossing",
     "shortname": ":children_crossing:",
@@ -12748,7 +12748,7 @@
     ]
   },
   "shield": {
-    "unicode": "1f6e1",
+    "unicode": "1F6E1",
     "unicode_alternates": [],
     "name": "shield",
     "shortname": ":shield:",
@@ -12765,7 +12765,7 @@
     ]
   },
   "mag": {
-    "unicode": "1f50d",
+    "unicode": "1F50D",
     "unicode_alternates": [],
     "name": "left-pointing magnifying glass",
     "shortname": ":mag:",
@@ -12782,7 +12782,7 @@
     ]
   },
   "mag_right": {
-    "unicode": "1f50e",
+    "unicode": "1F50E",
     "unicode_alternates": [],
     "name": "right-pointing magnifying glass",
     "shortname": ":mag_right:",
@@ -12799,7 +12799,7 @@
     ]
   },
   "speaking_head": {
-    "unicode": "1f5e3",
+    "unicode": "1F5E3",
     "unicode_alternates": [],
     "name": "speaking head in silhouette",
     "shortname": ":speaking_head:",
@@ -12814,7 +12814,7 @@
     ]
   },
   "sleeping_accommodation": {
-    "unicode": "1f6cc",
+    "unicode": "1F6CC",
     "unicode_alternates": [],
     "name": "sleeping accommodation",
     "shortname": ":sleeping_accommodation:",
@@ -12829,7 +12829,7 @@
     ]
   },
   "prohibited": {
-    "unicode": "1f6c7",
+    "unicode": "1F6C7",
     "unicode_alternates": [],
     "name": "prohibited sign",
     "shortname": ":prohibited:",
@@ -12850,7 +12850,7 @@
     ]
   },
   "no_entry_sign": {
-    "unicode": "1f6ab",
+    "unicode": "1F6AB",
     "unicode_alternates": [],
     "name": "no entry sign",
     "shortname": ":no_entry_sign:",
@@ -12868,7 +12868,7 @@
     ]
   },
   "no_entry": {
-    "unicode": "26d4",
+    "unicode": "26D4",
     "unicode_alternates": [
       "26D4-FE0F"
     ],
@@ -12888,7 +12888,7 @@
     ]
   },
   "name_badge": {
-    "unicode": "1f4db",
+    "unicode": "1F4DB",
     "unicode_alternates": [],
     "name": "name badge",
     "shortname": ":name_badge:",
@@ -12901,7 +12901,7 @@
     ]
   },
   "no_pedestrians": {
-    "unicode": "1f6b7",
+    "unicode": "1F6B7",
     "unicode_alternates": [],
     "name": "no pedestrians",
     "shortname": ":no_pedestrians:",
@@ -12919,7 +12919,7 @@
     ]
   },
   "do_not_litter": {
-    "unicode": "1f6af",
+    "unicode": "1F6AF",
     "unicode_alternates": [],
     "name": "do not litter symbol",
     "shortname": ":do_not_litter:",
@@ -12936,7 +12936,7 @@
     ]
   },
   "no_bicycles": {
-    "unicode": "1f6b3",
+    "unicode": "1F6B3",
     "unicode_alternates": [],
     "name": "no bicycles",
     "shortname": ":no_bicycles:",
@@ -12952,7 +12952,7 @@
     ]
   },
   "non-potable_water": {
-    "unicode": "1f6b1",
+    "unicode": "1F6B1",
     "unicode_alternates": [],
     "name": "non-potable water symbol",
     "shortname": ":non-potable_water:",
@@ -12972,7 +12972,7 @@
     ]
   },
   "no_mobile_phones": {
-    "unicode": "1f4f5",
+    "unicode": "1F4F5",
     "unicode_alternates": [],
     "name": "no mobile phones",
     "shortname": ":no_mobile_phones:",
@@ -12986,7 +12986,7 @@
     ]
   },
   "underage": {
-    "unicode": "1f51e",
+    "unicode": "1F51E",
     "unicode_alternates": [],
     "name": "no one under eighteen symbol",
     "shortname": ":underage:",
@@ -13002,7 +13002,7 @@
     ]
   },
   "piracy": {
-    "unicode": "1f572",
+    "unicode": "1F572",
     "unicode_alternates": [],
     "name": "no piracy",
     "shortname": ":piracy:",
@@ -13018,7 +13018,7 @@
     ]
   },
   "accept": {
-    "unicode": "1f251",
+    "unicode": "1F251",
     "unicode_alternates": [],
     "name": "circled ideograph accept",
     "shortname": ":accept:",
@@ -13036,7 +13036,7 @@
     ]
   },
   "ideograph_advantage": {
-    "unicode": "1f250",
+    "unicode": "1F250",
     "unicode_alternates": [],
     "name": "circled ideograph advantage",
     "shortname": ":ideograph_advantage:",
@@ -13052,7 +13052,7 @@
     ]
   },
   "white_flower": {
-    "unicode": "1f4ae",
+    "unicode": "1F4AE",
     "unicode_alternates": [],
     "name": "white flower",
     "shortname": ":white_flower:",
@@ -13107,7 +13107,7 @@
     ]
   },
   "u5408": {
-    "unicode": "1f234",
+    "unicode": "1F234",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-5408",
     "shortname": ":u5408:",
@@ -13125,7 +13125,7 @@
     ]
   },
   "u6e80": {
-    "unicode": "1f235",
+    "unicode": "1F235",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-6e80",
     "shortname": ":u6e80:",
@@ -13142,7 +13142,7 @@
     ]
   },
   "u7981": {
-    "unicode": "1f232",
+    "unicode": "1F232",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-7981",
     "shortname": ":u7981:",
@@ -13162,7 +13162,7 @@
     ]
   },
   "u6709": {
-    "unicode": "1f236",
+    "unicode": "1F236",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-6709",
     "shortname": ":u6709:",
@@ -13179,7 +13179,7 @@
     ]
   },
   "u7121": {
-    "unicode": "1f21a",
+    "unicode": "1F21A",
     "unicode_alternates": [
       "1F21A-FE0F"
     ],
@@ -13199,7 +13199,7 @@
     ]
   },
   "u7533": {
-    "unicode": "1f238",
+    "unicode": "1F238",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-7533",
     "shortname": ":u7533:",
@@ -13216,7 +13216,7 @@
     ]
   },
   "u55b6": {
-    "unicode": "1f23a",
+    "unicode": "1F23A",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-55b6",
     "shortname": ":u55b6:",
@@ -13231,7 +13231,7 @@
     ]
   },
   "u6708": {
-    "unicode": "1f237",
+    "unicode": "1F237",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-6708",
     "shortname": ":u6708:",
@@ -13249,7 +13249,7 @@
     ]
   },
   "u5272": {
-    "unicode": "1f239",
+    "unicode": "1F239",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-5272",
     "shortname": ":u5272:",
@@ -13268,7 +13268,7 @@
     ]
   },
   "u7a7a": {
-    "unicode": "1f233",
+    "unicode": "1F233",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-7a7a",
     "shortname": ":u7a7a:",
@@ -13284,7 +13284,7 @@
     ]
   },
   "sa": {
-    "unicode": "1f202",
+    "unicode": "1F202",
     "unicode_alternates": [],
     "name": "squared katakana sa",
     "shortname": ":sa:",
@@ -13298,7 +13298,7 @@
     ]
   },
   "koko": {
-    "unicode": "1f201",
+    "unicode": "1F201",
     "unicode_alternates": [],
     "name": "squared katakana koko",
     "shortname": ":koko:",
@@ -13314,7 +13314,7 @@
     ]
   },
   "u6307": {
-    "unicode": "1f22f",
+    "unicode": "1F22F",
     "unicode_alternates": [
       "1F22F-FE0F"
     ],
@@ -13332,7 +13332,7 @@
     ]
   },
   "chart": {
-    "unicode": "1f4b9",
+    "unicode": "1F4B9",
     "unicode_alternates": [],
     "name": "chart with upwards trend and yen sign",
     "shortname": ":chart:",
@@ -13379,7 +13379,7 @@
     ]
   },
   "negative_squared_cross_mark": {
-    "unicode": "274e",
+    "unicode": "274E",
     "unicode_alternates": [],
     "name": "negative squared cross mark",
     "shortname": ":negative_squared_cross_mark:",
@@ -13426,7 +13426,7 @@
     ]
   },
   "vibration_mode": {
-    "unicode": "1f4f3",
+    "unicode": "1F4F3",
     "unicode_alternates": [],
     "name": "vibration mode",
     "shortname": ":vibration_mode:",
@@ -13441,7 +13441,7 @@
     ]
   },
   "mobile_phone_off": {
-    "unicode": "1f4f4",
+    "unicode": "1F4F4",
     "unicode_alternates": [],
     "name": "mobile phone off",
     "shortname": ":mobile_phone_off:",
@@ -13454,7 +13454,7 @@
     ]
   },
   "vs": {
-    "unicode": "1f19a",
+    "unicode": "1F19A",
     "unicode_alternates": [],
     "name": "squared vs",
     "shortname": ":vs:",
@@ -13469,7 +13469,7 @@
     ]
   },
   "a": {
-    "unicode": "1f170",
+    "unicode": "1F170",
     "unicode_alternates": [],
     "name": "negative squared latin capital letter a",
     "shortname": ":a:",
@@ -13486,7 +13486,7 @@
     ]
   },
   "b": {
-    "unicode": "1f171",
+    "unicode": "1F171",
     "unicode_alternates": [],
     "name": "negative squared latin capital letter b",
     "shortname": ":b:",
@@ -13503,7 +13503,7 @@
     ]
   },
   "ab": {
-    "unicode": "1f18e",
+    "unicode": "1F18E",
     "unicode_alternates": [],
     "name": "negative squared ab",
     "shortname": ":ab:",
@@ -13519,7 +13519,7 @@
     ]
   },
   "cl": {
-    "unicode": "1f191",
+    "unicode": "1F191",
     "unicode_alternates": [],
     "name": "squared cl",
     "shortname": ":cl:",
@@ -13536,7 +13536,7 @@
     ]
   },
   "o2": {
-    "unicode": "1f17e",
+    "unicode": "1F17E",
     "unicode_alternates": [],
     "name": "negative squared latin capital letter o",
     "shortname": ":o2:",
@@ -13553,7 +13553,7 @@
     ]
   },
   "sos": {
-    "unicode": "1f198",
+    "unicode": "1F198",
     "unicode_alternates": [],
     "name": "squared sos",
     "shortname": ":sos:",
@@ -13569,7 +13569,7 @@
     ]
   },
   "id": {
-    "unicode": "1f194",
+    "unicode": "1F194",
     "unicode_alternates": [],
     "name": "squared id",
     "shortname": ":id:",
@@ -13583,7 +13583,7 @@
     ]
   },
   "parking": {
-    "unicode": "1f17f",
+    "unicode": "1F17F",
     "unicode_alternates": [
       "1F17F-FE0F"
     ],
@@ -13602,7 +13602,7 @@
     ]
   },
   "wc": {
-    "unicode": "1f6be",
+    "unicode": "1F6BE",
     "unicode_alternates": [],
     "name": "water closet",
     "shortname": ":wc:",
@@ -13624,7 +13624,7 @@
     ]
   },
   "cool": {
-    "unicode": "1f192",
+    "unicode": "1F192",
     "unicode_alternates": [],
     "name": "squared cool",
     "shortname": ":cool:",
@@ -13638,7 +13638,7 @@
     ]
   },
   "free": {
-    "unicode": "1f193",
+    "unicode": "1F193",
     "unicode_alternates": [],
     "name": "squared free",
     "shortname": ":free:",
@@ -13652,7 +13652,7 @@
     ]
   },
   "new": {
-    "unicode": "1f195",
+    "unicode": "1F195",
     "unicode_alternates": [],
     "name": "squared new",
     "shortname": ":new:",
@@ -13665,7 +13665,7 @@
     ]
   },
   "ng": {
-    "unicode": "1f196",
+    "unicode": "1F196",
     "unicode_alternates": [],
     "name": "squared ng",
     "shortname": ":ng:",
@@ -13679,7 +13679,7 @@
     ]
   },
   "ok": {
-    "unicode": "1f197",
+    "unicode": "1F197",
     "unicode_alternates": [],
     "name": "squared ok",
     "shortname": ":ok:",
@@ -13695,7 +13695,7 @@
     ]
   },
   "up": {
-    "unicode": "1f199",
+    "unicode": "1F199",
     "unicode_alternates": [],
     "name": "squared up with exclamation mark",
     "shortname": ":up:",
@@ -13708,7 +13708,7 @@
     ]
   },
   "atm": {
-    "unicode": "1f3e7",
+    "unicode": "1F3E7",
     "unicode_alternates": [],
     "name": "automated teller machine",
     "shortname": ":atm:",
@@ -13777,7 +13777,7 @@
     ]
   },
   "gemini": {
-    "unicode": "264a",
+    "unicode": "264A",
     "unicode_alternates": [
       "264A-FE0F"
     ],
@@ -13799,7 +13799,7 @@
     ]
   },
   "cancer": {
-    "unicode": "264b",
+    "unicode": "264B",
     "unicode_alternates": [
       "264B-FE0F"
     ],
@@ -13821,7 +13821,7 @@
     ]
   },
   "leo": {
-    "unicode": "264c",
+    "unicode": "264C",
     "unicode_alternates": [
       "264C-FE0F"
     ],
@@ -13844,7 +13844,7 @@
     ]
   },
   "virgo": {
-    "unicode": "264d",
+    "unicode": "264D",
     "unicode_alternates": [
       "264D-FE0F"
     ],
@@ -13866,7 +13866,7 @@
     ]
   },
   "libra": {
-    "unicode": "264e",
+    "unicode": "264E",
     "unicode_alternates": [
       "264E-FE0F"
     ],
@@ -13889,7 +13889,7 @@
     ]
   },
   "scorpius": {
-    "unicode": "264f",
+    "unicode": "264F",
     "unicode_alternates": [
       "264F-FE0F"
     ],
@@ -14005,7 +14005,7 @@
     ]
   },
   "restroom": {
-    "unicode": "1f6bb",
+    "unicode": "1F6BB",
     "unicode_alternates": [],
     "name": "restroom",
     "shortname": ":restroom:",
@@ -14024,7 +14024,7 @@
     ]
   },
   "mens": {
-    "unicode": "1f6b9",
+    "unicode": "1F6B9",
     "unicode_alternates": [],
     "name": "mens symbol",
     "shortname": ":mens:",
@@ -14045,7 +14045,7 @@
     ]
   },
   "womens": {
-    "unicode": "1f6ba",
+    "unicode": "1F6BA",
     "unicode_alternates": [],
     "name": "womens symbol",
     "shortname": ":womens:",
@@ -14065,7 +14065,7 @@
     ]
   },
   "boys_symbol": {
-    "unicode": "1f6c9",
+    "unicode": "1F6C9",
     "unicode_alternates": [],
     "name": "boys symbol",
     "shortname": ":boys_symbol:",
@@ -14079,7 +14079,7 @@
     ]
   },
   "girls_symbol": {
-    "unicode": "1f6ca",
+    "unicode": "1F6CA",
     "unicode_alternates": [],
     "name": "girls symbol",
     "shortname": ":girls_symbol:",
@@ -14093,7 +14093,7 @@
     ]
   },
   "baby_symbol": {
-    "unicode": "1f6bc",
+    "unicode": "1F6BC",
     "unicode_alternates": [],
     "name": "baby symbol",
     "shortname": ":baby_symbol:",
@@ -14113,7 +14113,7 @@
     ]
   },
   "wheelchair": {
-    "unicode": "267f",
+    "unicode": "267F",
     "unicode_alternates": [
       "267F-FE0F"
     ],
@@ -14130,7 +14130,7 @@
     ]
   },
   "potable_water": {
-    "unicode": "1f6b0",
+    "unicode": "1F6B0",
     "unicode_alternates": [],
     "name": "potable water symbol",
     "shortname": ":potable_water:",
@@ -14151,7 +14151,7 @@
     ]
   },
   "no_smoking": {
-    "unicode": "1f6ad",
+    "unicode": "1F6AD",
     "unicode_alternates": [],
     "name": "no smoking symbol",
     "shortname": ":no_smoking:",
@@ -14170,7 +14170,7 @@
     ]
   },
   "put_litter_in_its_place": {
-    "unicode": "1f6ae",
+    "unicode": "1F6AE",
     "unicode_alternates": [],
     "name": "put litter in its place symbol",
     "shortname": ":put_litter_in_its_place:",
@@ -14188,7 +14188,7 @@
     ]
   },
   "arrow_forward": {
-    "unicode": "25b6",
+    "unicode": "25B6",
     "unicode_alternates": [
       "25B6-FE0F"
     ],
@@ -14205,7 +14205,7 @@
     ]
   },
   "arrow_backward": {
-    "unicode": "25c0",
+    "unicode": "25C0",
     "unicode_alternates": [
       "25C0-FE0F"
     ],
@@ -14222,7 +14222,7 @@
     ]
   },
   "arrow_up_small": {
-    "unicode": "1f53c",
+    "unicode": "1F53C",
     "unicode_alternates": [],
     "name": "up-pointing small red triangle",
     "shortname": ":arrow_up_small:",
@@ -14236,7 +14236,7 @@
     ]
   },
   "arrow_down_small": {
-    "unicode": "1f53d",
+    "unicode": "1F53D",
     "unicode_alternates": [],
     "name": "down-pointing small red triangle",
     "shortname": ":arrow_down_small:",
@@ -14250,7 +14250,7 @@
     ]
   },
   "fast_forward": {
-    "unicode": "23e9",
+    "unicode": "23E9",
     "unicode_alternates": [],
     "name": "black right-pointing double triangle",
     "shortname": ":fast_forward:",
@@ -14265,7 +14265,7 @@
     ]
   },
   "rewind": {
-    "unicode": "23ea",
+    "unicode": "23EA",
     "unicode_alternates": [],
     "name": "black left-pointing double triangle",
     "shortname": ":rewind:",
@@ -14280,7 +14280,7 @@
     ]
   },
   "arrow_double_up": {
-    "unicode": "23eb",
+    "unicode": "23EB",
     "unicode_alternates": [],
     "name": "black up-pointing double triangle",
     "shortname": ":arrow_double_up:",
@@ -14294,7 +14294,7 @@
     ]
   },
   "arrow_double_down": {
-    "unicode": "23ec",
+    "unicode": "23EC",
     "unicode_alternates": [],
     "name": "black down-pointing double triangle",
     "shortname": ":arrow_double_down:",
@@ -14308,7 +14308,7 @@
     ]
   },
   "arrow_right": {
-    "unicode": "27a1",
+    "unicode": "27A1",
     "unicode_alternates": [
       "27A1-FE0F"
     ],
@@ -14326,7 +14326,7 @@
     ]
   },
   "arrow_left": {
-    "unicode": "2b05",
+    "unicode": "2B05",
     "unicode_alternates": [
       "2B05-FE0F"
     ],
@@ -14344,7 +14344,7 @@
     ]
   },
   "arrow_up": {
-    "unicode": "2b06",
+    "unicode": "2B06",
     "unicode_alternates": [
       "2B06-FE0F"
     ],
@@ -14360,7 +14360,7 @@
     ]
   },
   "arrow_down": {
-    "unicode": "2b07",
+    "unicode": "2B07",
     "unicode_alternates": [
       "2B07-FE0F"
     ],
@@ -14474,7 +14474,7 @@
     ]
   },
   "arrows_counterclockwise": {
-    "unicode": "1f504",
+    "unicode": "1F504",
     "unicode_alternates": [],
     "name": "anticlockwise downwards and upwards open circle arrows",
     "shortname": ":arrows_counterclockwise:",
@@ -14489,7 +14489,7 @@
     ]
   },
   "arrow_right_hook": {
-    "unicode": "21aa",
+    "unicode": "21AA",
     "unicode_alternates": [
       "21AA-FE0F"
     ],
@@ -14506,7 +14506,7 @@
     ]
   },
   "leftwards_arrow_with_hook": {
-    "unicode": "21a9",
+    "unicode": "21A9",
     "unicode_alternates": [
       "21A9-FE0F"
     ],
@@ -14557,7 +14557,7 @@
     ]
   },
   "twisted_rightwards_arrows": {
-    "unicode": "1f500",
+    "unicode": "1F500",
     "unicode_alternates": [],
     "name": "twisted rightwards arrows",
     "shortname": ":twisted_rightwards_arrows:",
@@ -14570,7 +14570,7 @@
     ]
   },
   "repeat": {
-    "unicode": "1f501",
+    "unicode": "1F501",
     "unicode_alternates": [],
     "name": "clockwise rightwards and leftwards open circle arrows",
     "shortname": ":repeat:",
@@ -14585,7 +14585,7 @@
     ]
   },
   "repeat_one": {
-    "unicode": "1f502",
+    "unicode": "1F502",
     "unicode_alternates": [],
     "name": "clockwise rightwards and leftwards open circle arrows",
     "shortname": ":repeat_one:",
@@ -14788,7 +14788,7 @@
     ]
   },
   "keycap_ten": {
-    "unicode": "1f51f",
+    "unicode": "1F51F",
     "unicode_alternates": [],
     "name": "keycap ten",
     "shortname": ":keycap_ten:",
@@ -14803,7 +14803,7 @@
     ]
   },
   "1234": {
-    "unicode": "1f522",
+    "unicode": "1F522",
     "unicode_alternates": [],
     "name": "input symbol for numbers",
     "shortname": ":1234:",
@@ -14816,7 +14816,7 @@
     ]
   },
   "abc": {
-    "unicode": "1f524",
+    "unicode": "1F524",
     "unicode_alternates": [],
     "name": "input symbol for latin letters",
     "shortname": ":abc:",
@@ -14830,7 +14830,7 @@
     ]
   },
   "abcd": {
-    "unicode": "1f521",
+    "unicode": "1F521",
     "unicode_alternates": [],
     "name": "input symbol for latin small letters",
     "shortname": ":abcd:",
@@ -14844,7 +14844,7 @@
     ]
   },
   "capital_abcd": {
-    "unicode": "1f520",
+    "unicode": "1F520",
     "unicode_alternates": [],
     "name": "input symbol for latin capital letters",
     "shortname": ":capital_abcd:",
@@ -14875,7 +14875,7 @@
     ]
   },
   "signal_strength": {
-    "unicode": "1f4f6",
+    "unicode": "1F4F6",
     "unicode_alternates": [],
     "name": "antenna with bars",
     "shortname": ":signal_strength:",
@@ -14889,7 +14889,7 @@
     ]
   },
   "cinema": {
-    "unicode": "1f3a6",
+    "unicode": "1F3A6",
     "unicode_alternates": [],
     "name": "cinema",
     "shortname": ":cinema:",
@@ -14908,7 +14908,7 @@
     ]
   },
   "symbols": {
-    "unicode": "1f523",
+    "unicode": "1F523",
     "unicode_alternates": [],
     "name": "input symbol for symbols",
     "shortname": ":symbols:",
@@ -15017,7 +15017,7 @@
     ]
   },
   "cancellation_x": {
-    "unicode": "1f5d9",
+    "unicode": "1F5D9",
     "unicode_alternates": [],
     "name": "cancellation x",
     "shortname": ":cancellation_x:",
@@ -15032,7 +15032,7 @@
     ]
   },
   "arrows_clockwise": {
-    "unicode": "1f503",
+    "unicode": "1F503",
     "unicode_alternates": [],
     "name": "clockwise downwards and upwards open circle arrows",
     "shortname": ":arrows_clockwise:",
@@ -15045,7 +15045,7 @@
     ]
   },
   "clockwise_arrows": {
-    "unicode": "1f5d8",
+    "unicode": "1F5D8",
     "unicode_alternates": [],
     "name": "clockwise right and left semicircle arrows",
     "shortname": ":clockwise_arrows:",
@@ -15074,7 +15074,7 @@
     ]
   },
   "copyright": {
-    "unicode": "00a9",
+    "unicode": "00A9",
     "unicode_alternates": [],
     "name": "copyright sign",
     "shortname": ":copyright:",
@@ -15088,7 +15088,7 @@
     ]
   },
   "registered": {
-    "unicode": "00ae",
+    "unicode": "00AE",
     "unicode_alternates": [],
     "name": "registered sign",
     "shortname": ":registered:",
@@ -15102,7 +15102,7 @@
     ]
   },
   "currency_exchange": {
-    "unicode": "1f4b1",
+    "unicode": "1F4B1",
     "unicode_alternates": [],
     "name": "currency exchange",
     "shortname": ":currency_exchange:",
@@ -15117,7 +15117,7 @@
     ]
   },
   "heavy_dollar_sign": {
-    "unicode": "1f4b2",
+    "unicode": "1F4B2",
     "unicode_alternates": [],
     "name": "heavy dollar sign",
     "shortname": ":heavy_dollar_sign:",
@@ -15136,7 +15136,7 @@
     ]
   },
   "curly_loop": {
-    "unicode": "27b0",
+    "unicode": "27B0",
     "unicode_alternates": [],
     "name": "curly loop",
     "shortname": ":curly_loop:",
@@ -15149,7 +15149,7 @@
     ]
   },
   "loop": {
-    "unicode": "27bf",
+    "unicode": "27BF",
     "unicode_alternates": [],
     "name": "double curly loop",
     "shortname": ":loop:",
@@ -15162,7 +15162,7 @@
     ]
   },
   "part_alternation_mark": {
-    "unicode": "303d",
+    "unicode": "303D",
     "unicode_alternates": [
       "303D-FE0F"
     ],
@@ -15242,7 +15242,7 @@
     ]
   },
   "bangbang": {
-    "unicode": "203c",
+    "unicode": "203C",
     "unicode_alternates": [
       "203C-FE0F"
     ],
@@ -15276,7 +15276,7 @@
     ]
   },
   "triangle_round": {
-    "unicode": "1f6c6",
+    "unicode": "1F6C6",
     "unicode_alternates": [],
     "name": "triangle with rounded corners",
     "shortname": ":triangle_round:",
@@ -15293,7 +15293,7 @@
     ]
   },
   "x": {
-    "unicode": "274c",
+    "unicode": "274C",
     "unicode_alternates": [],
     "name": "cross mark",
     "shortname": ":x:",
@@ -15310,7 +15310,7 @@
     ]
   },
   "o": {
-    "unicode": "2b55",
+    "unicode": "2B55",
     "unicode_alternates": [
       "2B55-FE0F"
     ],
@@ -15326,7 +15326,7 @@
     ]
   },
   "100": {
-    "unicode": "1f4af",
+    "unicode": "1F4AF",
     "unicode_alternates": [],
     "name": "hundred points symbol",
     "shortname": ":100:",
@@ -15350,7 +15350,7 @@
     ]
   },
   "end": {
-    "unicode": "1f51a",
+    "unicode": "1F51A",
     "unicode_alternates": [],
     "name": "end with leftwards arrow above",
     "shortname": ":end:",
@@ -15363,7 +15363,7 @@
     ]
   },
   "back": {
-    "unicode": "1f519",
+    "unicode": "1F519",
     "unicode_alternates": [],
     "name": "back with leftwards arrow above",
     "shortname": ":back:",
@@ -15376,7 +15376,7 @@
     ]
   },
   "on": {
-    "unicode": "1f51b",
+    "unicode": "1F51B",
     "unicode_alternates": [],
     "name": "on with exclamation mark with left right arrow abo",
     "shortname": ":on:",
@@ -15389,7 +15389,7 @@
     ]
   },
   "top": {
-    "unicode": "1f51d",
+    "unicode": "1F51D",
     "unicode_alternates": [],
     "name": "top with upwards arrow above",
     "shortname": ":top:",
@@ -15402,7 +15402,7 @@
     ]
   },
   "soon": {
-    "unicode": "1f51c",
+    "unicode": "1F51C",
     "unicode_alternates": [],
     "name": "soon with rightwards arrow above",
     "shortname": ":soon:",
@@ -15415,7 +15415,7 @@
     ]
   },
   "cyclone": {
-    "unicode": "1f300",
+    "unicode": "1F300",
     "unicode_alternates": [],
     "name": "cyclone",
     "shortname": ":cyclone:",
@@ -15435,7 +15435,7 @@
     ]
   },
   "m": {
-    "unicode": "24c2",
+    "unicode": "24C2",
     "unicode_alternates": [
       "24C2-FE0F"
     ],
@@ -15451,7 +15451,7 @@
     ]
   },
   "info": {
-    "unicode": "1f6c8",
+    "unicode": "1F6C8",
     "unicode_alternates": [],
     "name": "circled information source",
     "shortname": ":info:",
@@ -15466,7 +15466,7 @@
     ]
   },
   "ophiuchus": {
-    "unicode": "26ce",
+    "unicode": "26CE",
     "unicode_alternates": [],
     "name": "ophiuchus",
     "shortname": ":ophiuchus:",
@@ -15488,7 +15488,7 @@
     ]
   },
   "six_pointed_star": {
-    "unicode": "1f52f",
+    "unicode": "1F52F",
     "unicode_alternates": [],
     "name": "six pointed star with middle dot",
     "shortname": ":six_pointed_star:",
@@ -15501,7 +15501,7 @@
     ]
   },
   "beginner": {
-    "unicode": "1f530",
+    "unicode": "1F530",
     "unicode_alternates": [],
     "name": "japanese symbol for beginner",
     "shortname": ":beginner:",
@@ -15515,7 +15515,7 @@
     ]
   },
   "mood_lightning": {
-    "unicode": "1f5f2",
+    "unicode": "1F5F2",
     "unicode_alternates": [],
     "name": "lightning mood",
     "shortname": ":mood_lightning:",
@@ -15532,7 +15532,7 @@
     ]
   },
   "trident": {
-    "unicode": "1f531",
+    "unicode": "1F531",
     "unicode_alternates": [],
     "name": "trident emblem",
     "shortname": ":trident:",
@@ -15548,7 +15548,7 @@
     ]
   },
   "warning": {
-    "unicode": "26a0",
+    "unicode": "26A0",
     "unicode_alternates": [
       "26A0-FE0F"
     ],
@@ -15581,7 +15581,7 @@
     ]
   },
   "rosette": {
-    "unicode": "1f3f5",
+    "unicode": "1F3F5",
     "unicode_alternates": [],
     "name": "rosette",
     "shortname": ":rosette:",
@@ -15594,7 +15594,7 @@
     ]
   },
   "rosette_black": {
-    "unicode": "1f3f6",
+    "unicode": "1F3F6",
     "unicode_alternates": [],
     "name": "black rosette",
     "shortname": ":rosette_black:",
@@ -15607,7 +15607,7 @@
     ]
   },
   "recycle": {
-    "unicode": "267b",
+    "unicode": "267B",
     "unicode_alternates": [
       "267B-FE0F"
     ],
@@ -15625,7 +15625,7 @@
     ]
   },
   "anger": {
-    "unicode": "1f4a2",
+    "unicode": "1F4A2",
     "unicode_alternates": [],
     "name": "anger symbol",
     "shortname": ":anger:",
@@ -15639,7 +15639,7 @@
     ]
   },
   "diamond_shape_with_a_dot_inside": {
-    "unicode": "1f4a0",
+    "unicode": "1F4A0",
     "unicode_alternates": [],
     "name": "diamond shape with a dot inside",
     "shortname": ":diamond_shape_with_a_dot_inside:",
@@ -15737,7 +15737,7 @@
     ]
   },
   "light_check_mark": {
-    "unicode": "1f5f8",
+    "unicode": "1F5F8",
     "unicode_alternates": [],
     "name": "light check mark",
     "shortname": ":light_check_mark:",
@@ -15752,7 +15752,7 @@
     ]
   },
   "ballot_box_check": {
-    "unicode": "1f5f9",
+    "unicode": "1F5F9",
     "unicode_alternates": [],
     "name": "ballot box with bold check",
     "shortname": ":ballot_box_check:",
@@ -15768,7 +15768,7 @@
     ]
   },
   "ballot_x": {
-    "unicode": "1f5f4",
+    "unicode": "1F5F4",
     "unicode_alternates": [],
     "name": "ballot script x",
     "shortname": ":ballot_x:",
@@ -15784,7 +15784,7 @@
     ]
   },
   "ballot_box_x": {
-    "unicode": "1f5f5",
+    "unicode": "1F5F5",
     "unicode_alternates": [],
     "name": "ballot box with script x",
     "shortname": ":ballot_box_x:",
@@ -15800,7 +15800,7 @@
     ]
   },
   "white_circle": {
-    "unicode": "26aa",
+    "unicode": "26AA",
     "unicode_alternates": [
       "26AA-FE0F"
     ],
@@ -15815,7 +15815,7 @@
     ]
   },
   "black_circle": {
-    "unicode": "26ab",
+    "unicode": "26AB",
     "unicode_alternates": [
       "26AB-FE0F"
     ],
@@ -15830,7 +15830,7 @@
     ]
   },
   "radio_button": {
-    "unicode": "1f518",
+    "unicode": "1F518",
     "unicode_alternates": [],
     "name": "radio button",
     "shortname": ":radio_button:",
@@ -15843,7 +15843,7 @@
     ]
   },
   "red_circle": {
-    "unicode": "1f534",
+    "unicode": "1F534",
     "unicode_alternates": [],
     "name": "large red circle",
     "shortname": ":red_circle:",
@@ -15856,7 +15856,7 @@
     ]
   },
   "large_blue_circle": {
-    "unicode": "1f535",
+    "unicode": "1F535",
     "unicode_alternates": [],
     "name": "large blue circle",
     "shortname": ":large_blue_circle:",
@@ -15869,7 +15869,7 @@
     ]
   },
   "small_red_triangle": {
-    "unicode": "1f53a",
+    "unicode": "1F53A",
     "unicode_alternates": [],
     "name": "up-pointing red triangle",
     "shortname": ":small_red_triangle:",
@@ -15882,7 +15882,7 @@
     ]
   },
   "small_red_triangle_down": {
-    "unicode": "1f53b",
+    "unicode": "1F53B",
     "unicode_alternates": [],
     "name": "down-pointing red triangle",
     "shortname": ":small_red_triangle_down:",
@@ -15895,7 +15895,7 @@
     ]
   },
   "small_orange_diamond": {
-    "unicode": "1f538",
+    "unicode": "1F538",
     "unicode_alternates": [],
     "name": "small orange diamond",
     "shortname": ":small_orange_diamond:",
@@ -15908,7 +15908,7 @@
     ]
   },
   "small_blue_diamond": {
-    "unicode": "1f539",
+    "unicode": "1F539",
     "unicode_alternates": [],
     "name": "small blue diamond",
     "shortname": ":small_blue_diamond:",
@@ -15921,7 +15921,7 @@
     ]
   },
   "large_orange_diamond": {
-    "unicode": "1f536",
+    "unicode": "1F536",
     "unicode_alternates": [],
     "name": "large orange diamond",
     "shortname": ":large_orange_diamond:",
@@ -15934,7 +15934,7 @@
     ]
   },
   "large_blue_diamond": {
-    "unicode": "1f537",
+    "unicode": "1F537",
     "unicode_alternates": [],
     "name": "large blue diamond",
     "shortname": ":large_blue_diamond:",
@@ -15947,7 +15947,7 @@
     ]
   },
   "black_small_square": {
-    "unicode": "25aa",
+    "unicode": "25AA",
     "unicode_alternates": [
       "25AA-FE0F"
     ],
@@ -15962,7 +15962,7 @@
     ]
   },
   "white_small_square": {
-    "unicode": "25ab",
+    "unicode": "25AB",
     "unicode_alternates": [
       "25AB-FE0F"
     ],
@@ -15977,7 +15977,7 @@
     ]
   },
   "black_large_square": {
-    "unicode": "2b1b",
+    "unicode": "2B1B",
     "unicode_alternates": [
       "2B1B-FE0F"
     ],
@@ -15992,7 +15992,7 @@
     ]
   },
   "white_large_square": {
-    "unicode": "2b1c",
+    "unicode": "2B1C",
     "unicode_alternates": [
       "2B1C-FE0F"
     ],
@@ -16007,7 +16007,7 @@
     ]
   },
   "black_medium_square": {
-    "unicode": "25fc",
+    "unicode": "25FC",
     "unicode_alternates": [
       "25FC-FE0F"
     ],
@@ -16022,7 +16022,7 @@
     ]
   },
   "white_medium_square": {
-    "unicode": "25fb",
+    "unicode": "25FB",
     "unicode_alternates": [
       "25FB-FE0F"
     ],
@@ -16037,7 +16037,7 @@
     ]
   },
   "black_medium_small_square": {
-    "unicode": "25fe",
+    "unicode": "25FE",
     "unicode_alternates": [
       "25FE-FE0F"
     ],
@@ -16052,7 +16052,7 @@
     ]
   },
   "white_medium_small_square": {
-    "unicode": "25fd",
+    "unicode": "25FD",
     "unicode_alternates": [
       "25FD-FE0F"
     ],
@@ -16067,7 +16067,7 @@
     ]
   },
   "black_square_button": {
-    "unicode": "1f532",
+    "unicode": "1F532",
     "unicode_alternates": [],
     "name": "black square button",
     "shortname": ":black_square_button:",
@@ -16080,7 +16080,7 @@
     ]
   },
   "white_square_button": {
-    "unicode": "1f533",
+    "unicode": "1F533",
     "unicode_alternates": [],
     "name": "white square button",
     "shortname": ":white_square_button:",
@@ -16093,7 +16093,7 @@
     ]
   },
   "clock1": {
-    "unicode": "1f550",
+    "unicode": "1F550",
     "unicode_alternates": [],
     "name": "clock face one oclock",
     "shortname": ":clock1:",
@@ -16106,7 +16106,7 @@
     ]
   },
   "clock2": {
-    "unicode": "1f551",
+    "unicode": "1F551",
     "unicode_alternates": [],
     "name": "clock face two oclock",
     "shortname": ":clock2:",
@@ -16119,7 +16119,7 @@
     ]
   },
   "clock3": {
-    "unicode": "1f552",
+    "unicode": "1F552",
     "unicode_alternates": [],
     "name": "clock face three oclock",
     "shortname": ":clock3:",
@@ -16132,7 +16132,7 @@
     ]
   },
   "clock4": {
-    "unicode": "1f553",
+    "unicode": "1F553",
     "unicode_alternates": [],
     "name": "clock face four oclock",
     "shortname": ":clock4:",
@@ -16145,7 +16145,7 @@
     ]
   },
   "clock5": {
-    "unicode": "1f554",
+    "unicode": "1F554",
     "unicode_alternates": [],
     "name": "clock face five oclock",
     "shortname": ":clock5:",
@@ -16158,7 +16158,7 @@
     ]
   },
   "clock6": {
-    "unicode": "1f555",
+    "unicode": "1F555",
     "unicode_alternates": [],
     "name": "clock face six oclock",
     "shortname": ":clock6:",
@@ -16171,7 +16171,7 @@
     ]
   },
   "clock7": {
-    "unicode": "1f556",
+    "unicode": "1F556",
     "unicode_alternates": [],
     "name": "clock face seven oclock",
     "shortname": ":clock7:",
@@ -16184,7 +16184,7 @@
     ]
   },
   "clock8": {
-    "unicode": "1f557",
+    "unicode": "1F557",
     "unicode_alternates": [],
     "name": "clock face eight oclock",
     "shortname": ":clock8:",
@@ -16197,7 +16197,7 @@
     ]
   },
   "clock9": {
-    "unicode": "1f558",
+    "unicode": "1F558",
     "unicode_alternates": [],
     "name": "clock face nine oclock",
     "shortname": ":clock9:",
@@ -16210,7 +16210,7 @@
     ]
   },
   "clock10": {
-    "unicode": "1f559",
+    "unicode": "1F559",
     "unicode_alternates": [],
     "name": "clock face ten oclock",
     "shortname": ":clock10:",
@@ -16223,7 +16223,7 @@
     ]
   },
   "clock11": {
-    "unicode": "1f55a",
+    "unicode": "1F55A",
     "unicode_alternates": [],
     "name": "clock face eleven oclock",
     "shortname": ":clock11:",
@@ -16236,7 +16236,7 @@
     ]
   },
   "clock12": {
-    "unicode": "1f55b",
+    "unicode": "1F55B",
     "unicode_alternates": [],
     "name": "clock face twelve oclock",
     "shortname": ":clock12:",
@@ -16249,7 +16249,7 @@
     ]
   },
   "clock130": {
-    "unicode": "1f55c",
+    "unicode": "1F55C",
     "unicode_alternates": [],
     "name": "clock face one-thirty",
     "shortname": ":clock130:",
@@ -16262,7 +16262,7 @@
     ]
   },
   "clock230": {
-    "unicode": "1f55d",
+    "unicode": "1F55D",
     "unicode_alternates": [],
     "name": "clock face two-thirty",
     "shortname": ":clock230:",
@@ -16275,7 +16275,7 @@
     ]
   },
   "clock330": {
-    "unicode": "1f55e",
+    "unicode": "1F55E",
     "unicode_alternates": [],
     "name": "clock face three-thirty",
     "shortname": ":clock330:",
@@ -16288,7 +16288,7 @@
     ]
   },
   "clock430": {
-    "unicode": "1f55f",
+    "unicode": "1F55F",
     "unicode_alternates": [],
     "name": "clock face four-thirty",
     "shortname": ":clock430:",
@@ -16301,7 +16301,7 @@
     ]
   },
   "clock530": {
-    "unicode": "1f560",
+    "unicode": "1F560",
     "unicode_alternates": [],
     "name": "clock face five-thirty",
     "shortname": ":clock530:",
@@ -16314,7 +16314,7 @@
     ]
   },
   "clock630": {
-    "unicode": "1f561",
+    "unicode": "1F561",
     "unicode_alternates": [],
     "name": "clock face six-thirty",
     "shortname": ":clock630:",
@@ -16327,7 +16327,7 @@
     ]
   },
   "clock730": {
-    "unicode": "1f562",
+    "unicode": "1F562",
     "unicode_alternates": [],
     "name": "clock face seven-thirty",
     "shortname": ":clock730:",
@@ -16340,7 +16340,7 @@
     ]
   },
   "clock830": {
-    "unicode": "1f563",
+    "unicode": "1F563",
     "unicode_alternates": [],
     "name": "clock face eight-thirty",
     "shortname": ":clock830:",
@@ -16353,7 +16353,7 @@
     ]
   },
   "clock930": {
-    "unicode": "1f564",
+    "unicode": "1F564",
     "unicode_alternates": [],
     "name": "clock face nine-thirty",
     "shortname": ":clock930:",
@@ -16366,7 +16366,7 @@
     ]
   },
   "clock1030": {
-    "unicode": "1f565",
+    "unicode": "1F565",
     "unicode_alternates": [],
     "name": "clock face ten-thirty",
     "shortname": ":clock1030:",
@@ -16379,7 +16379,7 @@
     ]
   },
   "clock1130": {
-    "unicode": "1f566",
+    "unicode": "1F566",
     "unicode_alternates": [],
     "name": "clock face eleven-thirty",
     "shortname": ":clock1130:",
@@ -16392,7 +16392,7 @@
     ]
   },
   "clock1230": {
-    "unicode": "1f567",
+    "unicode": "1F567",
     "unicode_alternates": [],
     "name": "clock face twelve-thirty",
     "shortname": ":clock1230:",
@@ -16405,7 +16405,7 @@
     ]
   },
   "railway_car": {
-    "unicode": "1f683",
+    "unicode": "1F683",
     "unicode_alternates": [],
     "name": "railway car",
     "shortname": ":railway_car:",
@@ -16423,7 +16423,7 @@
     ]
   },
   "mountain_railway": {
-    "unicode": "1f69e",
+    "unicode": "1F69E",
     "unicode_alternates": [],
     "name": "mountain railway",
     "shortname": ":mountain_railway:",
@@ -16440,7 +16440,7 @@
     ]
   },
   "steam_locomotive": {
-    "unicode": "1f682",
+    "unicode": "1F682",
     "unicode_alternates": [],
     "name": "steam locomotive",
     "shortname": ":steam_locomotive:",
@@ -16456,7 +16456,7 @@
     ]
   },
   "train_diesel": {
-    "unicode": "1f6f2",
+    "unicode": "1F6F2",
     "unicode_alternates": [],
     "name": "diesel locomotive",
     "shortname": ":train_diesel:",
@@ -16474,7 +16474,7 @@
     ]
   },
   "train": {
-    "unicode": "1f68b",
+    "unicode": "1F68B",
     "unicode_alternates": [],
     "name": "Tram Car",
     "shortname": ":train:",
@@ -16490,7 +16490,7 @@
     ]
   },
   "monorail": {
-    "unicode": "1f69d",
+    "unicode": "1F69D",
     "unicode_alternates": [],
     "name": "monorail",
     "shortname": ":monorail:",
@@ -16507,7 +16507,7 @@
     ]
   },
   "bullettrain_side": {
-    "unicode": "1f684",
+    "unicode": "1F684",
     "unicode_alternates": [],
     "name": "high-speed train",
     "shortname": ":bullettrain_side:",
@@ -16525,7 +16525,7 @@
     ]
   },
   "bullettrain_front": {
-    "unicode": "1f685",
+    "unicode": "1F685",
     "unicode_alternates": [],
     "name": "high-speed train with bullet nose",
     "shortname": ":bullettrain_front:",
@@ -16543,7 +16543,7 @@
     ]
   },
   "train2": {
-    "unicode": "1f686",
+    "unicode": "1F686",
     "unicode_alternates": [],
     "name": "train",
     "shortname": ":train2:",
@@ -16560,7 +16560,7 @@
     ]
   },
   "metro": {
-    "unicode": "1f687",
+    "unicode": "1F687",
     "unicode_alternates": [],
     "name": "metro",
     "shortname": ":metro:",
@@ -16580,7 +16580,7 @@
     ]
   },
   "light_rail": {
-    "unicode": "1f688",
+    "unicode": "1F688",
     "unicode_alternates": [],
     "name": "light rail",
     "shortname": ":light_rail:",
@@ -16595,7 +16595,7 @@
     ]
   },
   "station": {
-    "unicode": "1f689",
+    "unicode": "1F689",
     "unicode_alternates": [],
     "name": "station",
     "shortname": ":station:",
@@ -16612,7 +16612,7 @@
     ]
   },
   "tram": {
-    "unicode": "1f68a",
+    "unicode": "1F68A",
     "unicode_alternates": [],
     "name": "tram",
     "shortname": ":tram:",
@@ -16629,7 +16629,7 @@
     ]
   },
   "railway_track": {
-    "unicode": "1f6e4",
+    "unicode": "1F6E4",
     "unicode_alternates": [],
     "name": "railway track",
     "shortname": ":railway_track:",
@@ -16648,7 +16648,7 @@
     ]
   },
   "bus": {
-    "unicode": "1f68c",
+    "unicode": "1F68C",
     "unicode_alternates": [],
     "name": "bus",
     "shortname": ":bus:",
@@ -16666,7 +16666,7 @@
     ]
   },
   "oncoming_bus": {
-    "unicode": "1f68d",
+    "unicode": "1F68D",
     "unicode_alternates": [],
     "name": "oncoming bus",
     "shortname": ":oncoming_bus:",
@@ -16684,7 +16684,7 @@
     ]
   },
   "trolleybus": {
-    "unicode": "1f68e",
+    "unicode": "1F68E",
     "unicode_alternates": [],
     "name": "trolleybus",
     "shortname": ":trolleybus:",
@@ -16702,7 +16702,7 @@
     ]
   },
   "minibus": {
-    "unicode": "1f690",
+    "unicode": "1F690",
     "unicode_alternates": [],
     "name": "minibus",
     "shortname": ":minibus:",
@@ -16719,7 +16719,7 @@
     ]
   },
   "ambulance": {
-    "unicode": "1f691",
+    "unicode": "1F691",
     "unicode_alternates": [],
     "name": "ambulance",
     "shortname": ":ambulance:",
@@ -16737,7 +16737,7 @@
     ]
   },
   "fire_engine": {
-    "unicode": "1f692",
+    "unicode": "1F692",
     "unicode_alternates": [],
     "name": "fire engine",
     "shortname": ":fire_engine:",
@@ -16754,7 +16754,7 @@
     ]
   },
   "fire_engine_oncoming": {
-    "unicode": "1f6f1",
+    "unicode": "1F6F1",
     "unicode_alternates": [],
     "name": "oncoming fire engine",
     "shortname": ":fire_engine_oncoming:",
@@ -16773,7 +16773,7 @@
     ]
   },
   "police_car": {
-    "unicode": "1f693",
+    "unicode": "1F693",
     "unicode_alternates": [],
     "name": "police car",
     "shortname": ":police_car:",
@@ -16798,7 +16798,7 @@
     ]
   },
   "oncoming_police_car": {
-    "unicode": "1f694",
+    "unicode": "1F694",
     "unicode_alternates": [],
     "name": "oncoming police car",
     "shortname": ":oncoming_police_car:",
@@ -16819,7 +16819,7 @@
     ]
   },
   "rotating_light": {
-    "unicode": "1f6a8",
+    "unicode": "1F6A8",
     "unicode_alternates": [],
     "name": "police cars revolving light",
     "shortname": ":rotating_light:",
@@ -16837,7 +16837,7 @@
     ]
   },
   "taxi": {
-    "unicode": "1f695",
+    "unicode": "1F695",
     "unicode_alternates": [],
     "name": "taxi",
     "shortname": ":taxi:",
@@ -16858,7 +16858,7 @@
     ]
   },
   "oncoming_taxi": {
-    "unicode": "1f696",
+    "unicode": "1F696",
     "unicode_alternates": [],
     "name": "oncoming taxi",
     "shortname": ":oncoming_taxi:",
@@ -16878,7 +16878,7 @@
     ]
   },
   "red_car": {
-    "unicode": "1f697",
+    "unicode": "1F697",
     "unicode_alternates": [],
     "name": "automobile",
     "shortname": ":red_car:",
@@ -16894,7 +16894,7 @@
     ]
   },
   "oncoming_automobile": {
-    "unicode": "1f698",
+    "unicode": "1F698",
     "unicode_alternates": [],
     "name": "oncoming automobile",
     "shortname": ":oncoming_automobile:",
@@ -16912,7 +16912,7 @@
     ]
   },
   "blue_car": {
-    "unicode": "1f699",
+    "unicode": "1F699",
     "unicode_alternates": [],
     "name": "recreational vehicle",
     "shortname": ":blue_car:",
@@ -16929,7 +16929,7 @@
     ]
   },
   "truck": {
-    "unicode": "1f69a",
+    "unicode": "1F69A",
     "unicode_alternates": [],
     "name": "delivery truck",
     "shortname": ":truck:",
@@ -16945,7 +16945,7 @@
     ]
   },
   "articulated_lorry": {
-    "unicode": "1f69b",
+    "unicode": "1F69B",
     "unicode_alternates": [],
     "name": "articulated lorry",
     "shortname": ":articulated_lorry:",
@@ -16962,7 +16962,7 @@
     ]
   },
   "tractor": {
-    "unicode": "1f69c",
+    "unicode": "1F69C",
     "unicode_alternates": [],
     "name": "tractor",
     "shortname": ":tractor:",
@@ -16980,7 +16980,7 @@
     ]
   },
   "bike": {
-    "unicode": "1f6b2",
+    "unicode": "1F6B2",
     "unicode_alternates": [],
     "name": "bicycle",
     "shortname": ":bike:",
@@ -16998,7 +16998,7 @@
     ]
   },
   "motorway": {
-    "unicode": "1f6e3",
+    "unicode": "1F6E3",
     "unicode_alternates": [],
     "name": "motorway",
     "shortname": ":motorway:",
@@ -17015,7 +17015,7 @@
     ]
   },
   "busstop": {
-    "unicode": "1f68f",
+    "unicode": "1F68F",
     "unicode_alternates": [],
     "name": "bus stop",
     "shortname": ":busstop:",
@@ -17030,7 +17030,7 @@
     ]
   },
   "fuelpump": {
-    "unicode": "26fd",
+    "unicode": "26FD",
     "unicode_alternates": [
       "26FD-FE0F"
     ],
@@ -17048,7 +17048,7 @@
     ]
   },
   "construction": {
-    "unicode": "1f6a7",
+    "unicode": "1F6A7",
     "unicode_alternates": [],
     "name": "construction sign",
     "shortname": ":construction:",
@@ -17063,7 +17063,7 @@
     ]
   },
   "vertical_traffic_light": {
-    "unicode": "1f6a6",
+    "unicode": "1F6A6",
     "unicode_alternates": [],
     "name": "vertical traffic light",
     "shortname": ":vertical_traffic_light:",
@@ -17080,7 +17080,7 @@
     ]
   },
   "traffic_light": {
-    "unicode": "1f6a5",
+    "unicode": "1F6A5",
     "unicode_alternates": [],
     "name": "horizontal traffic light",
     "shortname": ":traffic_light:",
@@ -17097,7 +17097,7 @@
     ]
   },
   "rocket": {
-    "unicode": "1f680",
+    "unicode": "1F680",
     "unicode_alternates": [],
     "name": "rocket",
     "shortname": ":rocket:",
@@ -17116,7 +17116,7 @@
     ]
   },
   "helicopter": {
-    "unicode": "1f681",
+    "unicode": "1F681",
     "unicode_alternates": [],
     "name": "helicopter",
     "shortname": ":helicopter:",
@@ -17159,7 +17159,7 @@
     ]
   },
   "airplane_up": {
-    "unicode": "1f6e7",
+    "unicode": "1F6E7",
     "unicode_alternates": [],
     "name": "up-pointing airplane",
     "shortname": ":airplane_up:",
@@ -17175,7 +17175,7 @@
     ]
   },
   "airplane_small_up": {
-    "unicode": "1f6e8",
+    "unicode": "1F6E8",
     "unicode_alternates": [],
     "name": "up-pointing small airplane",
     "shortname": ":airplane_small_up:",
@@ -17191,7 +17191,7 @@
     ]
   },
   "jet_up": {
-    "unicode": "1f6e6",
+    "unicode": "1F6E6",
     "unicode_alternates": [],
     "name": "up-pointing military airplane",
     "shortname": ":jet_up:",
@@ -17206,7 +17206,7 @@
     ]
   },
   "airplane_northeast": {
-    "unicode": "1f6ea",
+    "unicode": "1F6EA",
     "unicode_alternates": [],
     "name": "northeast-pointing airplane",
     "shortname": ":airplane_northeast:",
@@ -17222,7 +17222,7 @@
     ]
   },
   "airplane_small": {
-    "unicode": "1f6e9",
+    "unicode": "1F6E9",
     "unicode_alternates": [],
     "name": "small airplane",
     "shortname": ":airplane_small:",
@@ -17248,7 +17248,7 @@
     ]
   },
   "airplane_departure": {
-    "unicode": "1f6eb",
+    "unicode": "1F6EB",
     "unicode_alternates": [],
     "name": "airplane departure",
     "shortname": ":airplane_departure:",
@@ -17273,7 +17273,7 @@
     ]
   },
   "airplane_arriving": {
-    "unicode": "1f6ec",
+    "unicode": "1F6EC",
     "unicode_alternates": [],
     "name": "airplane arriving",
     "shortname": ":airplane_arriving:",
@@ -17297,7 +17297,7 @@
     ]
   },
   "seat": {
-    "unicode": "1f4ba",
+    "unicode": "1F4BA",
     "unicode_alternates": [],
     "name": "seat",
     "shortname": ":seat:",
@@ -17334,7 +17334,7 @@
     ]
   },
   "ship": {
-    "unicode": "1f6a2",
+    "unicode": "1F6A2",
     "unicode_alternates": [],
     "name": "ship",
     "shortname": ":ship:",
@@ -17351,7 +17351,7 @@
     ]
   },
   "cruise_ship": {
-    "unicode": "1f6f3",
+    "unicode": "1F6F3",
     "unicode_alternates": [],
     "name": "passenger ship",
     "shortname": ":cruise_ship:",
@@ -17368,7 +17368,7 @@
     ]
   },
   "motorboat": {
-    "unicode": "1f6e5",
+    "unicode": "1F6E5",
     "unicode_alternates": [],
     "name": "motorboat",
     "shortname": ":motorboat:",
@@ -17385,7 +17385,7 @@
     ]
   },
   "speedboat": {
-    "unicode": "1f6a4",
+    "unicode": "1F6A4",
     "unicode_alternates": [],
     "name": "speedboat",
     "shortname": ":speedboat:",
@@ -17402,7 +17402,7 @@
     ]
   },
   "sailboat": {
-    "unicode": "26f5",
+    "unicode": "26F5",
     "unicode_alternates": [
       "26F5-FE0F"
     ],
@@ -17424,7 +17424,7 @@
     ]
   },
   "aerial_tramway": {
-    "unicode": "1f6a1",
+    "unicode": "1F6A1",
     "unicode_alternates": [],
     "name": "aerial tramway",
     "shortname": ":aerial_tramway:",
@@ -17441,7 +17441,7 @@
     ]
   },
   "mountain_cableway": {
-    "unicode": "1f6a0",
+    "unicode": "1F6A0",
     "unicode_alternates": [],
     "name": "mountain cableway",
     "shortname": ":mountain_cableway:",
@@ -17456,7 +17456,7 @@
     ]
   },
   "suspension_railway": {
-    "unicode": "1f69f",
+    "unicode": "1F69F",
     "unicode_alternates": [],
     "name": "suspension railway",
     "shortname": ":suspension_railway:",
@@ -17471,7 +17471,7 @@
     ]
   },
   "passport_control": {
-    "unicode": "1f6c2",
+    "unicode": "1F6C2",
     "unicode_alternates": [],
     "name": "passport control",
     "shortname": ":passport_control:",
@@ -17493,7 +17493,7 @@
     ]
   },
   "customs": {
-    "unicode": "1f6c3",
+    "unicode": "1F6C3",
     "unicode_alternates": [],
     "name": "customs",
     "shortname": ":customs:",
@@ -17515,7 +17515,7 @@
     ]
   },
   "baggage_claim": {
-    "unicode": "1f6c4",
+    "unicode": "1F6C4",
     "unicode_alternates": [],
     "name": "baggage claim",
     "shortname": ":baggage_claim:",
@@ -17534,7 +17534,7 @@
     ]
   },
   "left_luggage": {
-    "unicode": "1f6c5",
+    "unicode": "1F6C5",
     "unicode_alternates": [],
     "name": "left luggage",
     "shortname": ":left_luggage:",
@@ -17551,7 +17551,7 @@
     ]
   },
   "yen": {
-    "unicode": "1f4b4",
+    "unicode": "1F4B4",
     "unicode_alternates": [],
     "name": "banknote with yen sign",
     "shortname": ":yen:",
@@ -17571,7 +17571,7 @@
     ]
   },
   "euro": {
-    "unicode": "1f4b6",
+    "unicode": "1F4B6",
     "unicode_alternates": [],
     "name": "banknote with euro sign",
     "shortname": ":euro:",
@@ -17590,7 +17590,7 @@
     ]
   },
   "pound": {
-    "unicode": "1f4b7",
+    "unicode": "1F4B7",
     "unicode_alternates": [],
     "name": "banknote with pound sign",
     "shortname": ":pound:",
@@ -17612,7 +17612,7 @@
     ]
   },
   "dollar": {
-    "unicode": "1f4b5",
+    "unicode": "1F4B5",
     "unicode_alternates": [],
     "name": "banknote with dollar sign",
     "shortname": ":dollar:",
@@ -17632,7 +17632,7 @@
     ]
   },
   "bellhop": {
-    "unicode": "1f6ce",
+    "unicode": "1F6CE",
     "unicode_alternates": [],
     "name": "bellhop bell",
     "shortname": ":bellhop:",
@@ -17649,7 +17649,7 @@
     ]
   },
   "bed": {
-    "unicode": "1f6cf",
+    "unicode": "1F6CF",
     "unicode_alternates": [],
     "name": "bed",
     "shortname": ":bed:",
@@ -17668,7 +17668,7 @@
     ]
   },
   "couch": {
-    "unicode": "1f6cb",
+    "unicode": "1F6CB",
     "unicode_alternates": [],
     "name": "couch and lamp",
     "shortname": ":couch:",
@@ -17690,7 +17690,7 @@
     ]
   },
   "fork_knife_plate": {
-    "unicode": "1f37d",
+    "unicode": "1F37D",
     "unicode_alternates": [],
     "name": "fork and knife with plate",
     "shortname": ":fork_knife_plate:",
@@ -17711,7 +17711,7 @@
     ]
   },
   "shopping_bags": {
-    "unicode": "1f6cd",
+    "unicode": "1F6CD",
     "unicode_alternates": [],
     "name": "shopping bags",
     "shortname": ":shopping_bags:",
@@ -17728,7 +17728,7 @@
     ]
   },
   "statue_of_liberty": {
-    "unicode": "1f5fd",
+    "unicode": "1F5FD",
     "unicode_alternates": [],
     "name": "statue of liberty",
     "shortname": ":statue_of_liberty:",
@@ -17743,7 +17743,7 @@
     ]
   },
   "moyai": {
-    "unicode": "1f5ff",
+    "unicode": "1F5FF",
     "unicode_alternates": [],
     "name": "moyai",
     "shortname": ":moyai:",
@@ -17757,7 +17757,7 @@
     ]
   },
   "foggy": {
-    "unicode": "1f301",
+    "unicode": "1F301",
     "unicode_alternates": [],
     "name": "foggy",
     "shortname": ":foggy:",
@@ -17773,7 +17773,7 @@
     ]
   },
   "tokyo_tower": {
-    "unicode": "1f5fc",
+    "unicode": "1F5FC",
     "unicode_alternates": [],
     "name": "tokyo tower",
     "shortname": ":tokyo_tower:",
@@ -17786,7 +17786,7 @@
     ]
   },
   "fountain": {
-    "unicode": "26f2",
+    "unicode": "26F2",
     "unicode_alternates": [
       "26F2-FE0F"
     ],
@@ -17806,7 +17806,7 @@
     ]
   },
   "european_castle": {
-    "unicode": "1f3f0",
+    "unicode": "1F3F0",
     "unicode_alternates": [],
     "name": "european castle",
     "shortname": ":european_castle:",
@@ -17836,7 +17836,7 @@
     ]
   },
   "japanese_castle": {
-    "unicode": "1f3ef",
+    "unicode": "1F3EF",
     "unicode_alternates": [],
     "name": "japanese castle",
     "shortname": ":japanese_castle:",
@@ -17855,7 +17855,7 @@
     ]
   },
   "classical_building": {
-    "unicode": "1f3db",
+    "unicode": "1F3DB",
     "unicode_alternates": [],
     "name": "classical building",
     "shortname": ":classical_building:",
@@ -17872,7 +17872,7 @@
     ]
   },
   "stadium": {
-    "unicode": "1f3df",
+    "unicode": "1F3DF",
     "unicode_alternates": [],
     "name": "stadium",
     "shortname": ":stadium:",
@@ -17889,7 +17889,7 @@
     ]
   },
   "mountain_snow": {
-    "unicode": "1f3d4",
+    "unicode": "1F3D4",
     "unicode_alternates": [],
     "name": "snow capped mountain",
     "shortname": ":mountain_snow:",
@@ -17907,7 +17907,7 @@
     ]
   },
   "camping": {
-    "unicode": "1f3d5",
+    "unicode": "1F3D5",
     "unicode_alternates": [],
     "name": "camping",
     "shortname": ":camping:",
@@ -17924,7 +17924,7 @@
     ]
   },
   "beach": {
-    "unicode": "1f3d6",
+    "unicode": "1F3D6",
     "unicode_alternates": [],
     "name": "beach with umbrella",
     "shortname": ":beach:",
@@ -17946,7 +17946,7 @@
     ]
   },
   "desert": {
-    "unicode": "1f3dc",
+    "unicode": "1F3DC",
     "unicode_alternates": [],
     "name": "desert",
     "shortname": ":desert:",
@@ -17964,7 +17964,7 @@
     ]
   },
   "island": {
-    "unicode": "1f3dd",
+    "unicode": "1F3DD",
     "unicode_alternates": [],
     "name": "desert island",
     "shortname": ":island:",
@@ -17981,7 +17981,7 @@
     ]
   },
   "park": {
-    "unicode": "1f3de",
+    "unicode": "1F3DE",
     "unicode_alternates": [],
     "name": "national park",
     "shortname": ":park:",
@@ -18001,7 +18001,7 @@
     ]
   },
   "cityscape": {
-    "unicode": "1f3d9",
+    "unicode": "1F3D9",
     "unicode_alternates": [],
     "name": "cityscape",
     "shortname": ":cityscape:",
@@ -18019,7 +18019,7 @@
     ]
   },
   "city_sunset": {
-    "unicode": "1f307",
+    "unicode": "1F307",
     "unicode_alternates": [],
     "name": "sunset over buildings",
     "shortname": ":city_sunset:",
@@ -18041,7 +18041,7 @@
     ]
   },
   "city_dusk": {
-    "unicode": "1f306",
+    "unicode": "1F306",
     "unicode_alternates": [],
     "name": "cityscape at dusk",
     "shortname": ":city_dusk:",
@@ -18061,7 +18061,7 @@
     ]
   },
   "night_with_stars": {
-    "unicode": "1f303",
+    "unicode": "1F303",
     "unicode_alternates": [],
     "name": "night with stars",
     "shortname": ":night_with_stars:",
@@ -18078,7 +18078,7 @@
     ]
   },
   "bridge_at_night": {
-    "unicode": "1f309",
+    "unicode": "1F309",
     "unicode_alternates": [],
     "name": "bridge at night",
     "shortname": ":bridge_at_night:",
@@ -18096,7 +18096,7 @@
     ]
   },
   "house": {
-    "unicode": "1f3e0",
+    "unicode": "1F3E0",
     "unicode_alternates": [],
     "name": "house building",
     "shortname": ":house:",
@@ -18115,7 +18115,7 @@
     ]
   },
   "homes": {
-    "unicode": "1f3d8",
+    "unicode": "1F3D8",
     "unicode_alternates": [],
     "name": "house buildings",
     "shortname": ":homes:",
@@ -18136,7 +18136,7 @@
     ]
   },
   "house_with_garden": {
-    "unicode": "1f3e1",
+    "unicode": "1F3E1",
     "unicode_alternates": [],
     "name": "house with garden",
     "shortname": ":house_with_garden:",
@@ -18158,7 +18158,7 @@
     ]
   },
   "house_abandoned": {
-    "unicode": "1f3da",
+    "unicode": "1F3DA",
     "unicode_alternates": [],
     "name": "derelict house building",
     "shortname": ":house_abandoned:",
@@ -18184,7 +18184,7 @@
     ]
   },
   "contruction_site": {
-    "unicode": "1f3d7",
+    "unicode": "1F3D7",
     "unicode_alternates": [],
     "name": "building construction",
     "shortname": ":contruction_site:",
@@ -18200,7 +18200,7 @@
     ]
   },
   "office": {
-    "unicode": "1f3e2",
+    "unicode": "1F3E2",
     "unicode_alternates": [],
     "name": "office building",
     "shortname": ":office:",
@@ -18215,7 +18215,7 @@
     ]
   },
   "department_store": {
-    "unicode": "1f3ec",
+    "unicode": "1F3EC",
     "unicode_alternates": [],
     "name": "department store",
     "shortname": ":department_store:",
@@ -18233,7 +18233,7 @@
     ]
   },
   "factory": {
-    "unicode": "1f3ed",
+    "unicode": "1F3ED",
     "unicode_alternates": [],
     "name": "factory",
     "shortname": ":factory:",
@@ -18248,7 +18248,7 @@
     ]
   },
   "post_office": {
-    "unicode": "1f3e3",
+    "unicode": "1F3E3",
     "unicode_alternates": [],
     "name": "japanese post office",
     "shortname": ":post_office:",
@@ -18265,7 +18265,7 @@
     ]
   },
   "european_post_office": {
-    "unicode": "1f3e4",
+    "unicode": "1F3E4",
     "unicode_alternates": [],
     "name": "european post office",
     "shortname": ":european_post_office:",
@@ -18282,7 +18282,7 @@
     ]
   },
   "hospital": {
-    "unicode": "1f3e5",
+    "unicode": "1F3E5",
     "unicode_alternates": [],
     "name": "hospital",
     "shortname": ":hospital:",
@@ -18298,7 +18298,7 @@
     ]
   },
   "bank": {
-    "unicode": "1f3e6",
+    "unicode": "1F3E6",
     "unicode_alternates": [],
     "name": "bank",
     "shortname": ":bank:",
@@ -18314,7 +18314,7 @@
     ]
   },
   "hotel": {
-    "unicode": "1f3e8",
+    "unicode": "1F3E8",
     "unicode_alternates": [],
     "name": "hotel",
     "shortname": ":hotel:",
@@ -18331,7 +18331,7 @@
     ]
   },
   "love_hotel": {
-    "unicode": "1f3e9",
+    "unicode": "1F3E9",
     "unicode_alternates": [],
     "name": "love hotel",
     "shortname": ":love_hotel:",
@@ -18353,7 +18353,7 @@
     ]
   },
   "wedding": {
-    "unicode": "1f492",
+    "unicode": "1F492",
     "unicode_alternates": [],
     "name": "wedding",
     "shortname": ":wedding:",
@@ -18373,7 +18373,7 @@
     ]
   },
   "church": {
-    "unicode": "26ea",
+    "unicode": "26EA",
     "unicode_alternates": [
       "26EA-FE0F"
     ],
@@ -18390,7 +18390,7 @@
     ]
   },
   "convenience_store": {
-    "unicode": "1f3ea",
+    "unicode": "1F3EA",
     "unicode_alternates": [],
     "name": "convenience store",
     "shortname": ":convenience_store:",
@@ -18406,7 +18406,7 @@
     ]
   },
   "school": {
-    "unicode": "1f3eb",
+    "unicode": "1F3EB",
     "unicode_alternates": [],
     "name": "school",
     "shortname": ":school:",
@@ -18426,7 +18426,7 @@
     ]
   },
   "map": {
-    "unicode": "1f5fa",
+    "unicode": "1F5FA",
     "unicode_alternates": [],
     "name": "world map",
     "shortname": ":map:",
@@ -18443,7 +18443,7 @@
     ]
   },
   "flag_au": {
-    "unicode": "1f1e6-1F1FA",
+    "unicode": "1F1E6-1F1FA",
     "unicode_alternates": [],
     "name": "australia",
     "shortname": ":flag_au:",
@@ -18460,7 +18460,7 @@
     ]
   },
   "flag_at": {
-    "unicode": "1f1e6-1F1F9",
+    "unicode": "1F1E6-1F1F9",
     "unicode_alternates": [],
     "name": "austria",
     "shortname": ":flag_at:",
@@ -18479,7 +18479,7 @@
     ]
   },
   "flag_be": {
-    "unicode": "1f1e7-1F1EA",
+    "unicode": "1F1E7-1F1EA",
     "unicode_alternates": [],
     "name": "belgium",
     "shortname": ":flag_be:",
@@ -18498,7 +18498,7 @@
     ]
   },
   "flag_br": {
-    "unicode": "1f1e7-1F1F7",
+    "unicode": "1F1E7-1F1F7",
     "unicode_alternates": [],
     "name": "brazil",
     "shortname": ":flag_br:",
@@ -18516,7 +18516,7 @@
     ]
   },
   "flag_ca": {
-    "unicode": "1f1e8-1F1E6",
+    "unicode": "1F1E8-1F1E6",
     "unicode_alternates": [],
     "name": "canada",
     "shortname": ":flag_ca:",
@@ -18533,7 +18533,7 @@
     ]
   },
   "flag_cl": {
-    "unicode": "1f1e8-1F1F1",
+    "unicode": "1F1E8-1F1F1",
     "unicode_alternates": [],
     "name": "chile",
     "shortname": ":flag_cl:",
@@ -18550,7 +18550,7 @@
     ]
   },
   "flag_cn": {
-    "unicode": "1f1e8-1F1F3",
+    "unicode": "1F1E8-1F1F3",
     "unicode_alternates": [],
     "name": "china",
     "shortname": ":flag_cn:",
@@ -18570,7 +18570,7 @@
     ]
   },
   "flag_co": {
-    "unicode": "1f1e8-1F1F4",
+    "unicode": "1F1E8-1F1F4",
     "unicode_alternates": [],
     "name": "colombia",
     "shortname": ":flag_co:",
@@ -18587,7 +18587,7 @@
     ]
   },
   "flag_dk": {
-    "unicode": "1f1e9-1F1F0",
+    "unicode": "1F1E9-1F1F0",
     "unicode_alternates": [],
     "name": "denmark",
     "shortname": ":flag_dk:",
@@ -18605,7 +18605,7 @@
     ]
   },
   "flag_fi": {
-    "unicode": "1f1eb-1F1EE",
+    "unicode": "1F1EB-1F1EE",
     "unicode_alternates": [],
     "name": "finland",
     "shortname": ":flag_fi:",
@@ -18623,7 +18623,7 @@
     ]
   },
   "flag_fr": {
-    "unicode": "1f1eb-1F1F7",
+    "unicode": "1F1EB-1F1F7",
     "unicode_alternates": [],
     "name": "france",
     "shortname": ":flag_fr:",
@@ -18641,7 +18641,7 @@
     ]
   },
   "flag_de": {
-    "unicode": "1f1e9-1F1EA",
+    "unicode": "1F1E9-1F1EA",
     "unicode_alternates": [],
     "name": "germany",
     "shortname": ":flag_de:",
@@ -18660,7 +18660,7 @@
     ]
   },
   "flag_hk": {
-    "unicode": "1f1ed-1F1F0",
+    "unicode": "1F1ED-1F1F0",
     "unicode_alternates": [],
     "name": "hong kong",
     "shortname": ":flag_hk:",
@@ -18678,7 +18678,7 @@
     ]
   },
   "flag_in": {
-    "unicode": "1f1ee-1F1F3",
+    "unicode": "1F1EE-1F1F3",
     "unicode_alternates": [],
     "name": "india",
     "shortname": ":flag_in:",
@@ -18696,7 +18696,7 @@
     ]
   },
   "flag_id": {
-    "unicode": "1f1ee-1F1E9",
+    "unicode": "1F1EE-1F1E9",
     "unicode_alternates": [],
     "name": "indonesia",
     "shortname": ":flag_id:",
@@ -18713,7 +18713,7 @@
     ]
   },
   "flag_ie": {
-    "unicode": "1f1ee-1F1EA",
+    "unicode": "1F1EE-1F1EA",
     "unicode_alternates": [],
     "name": "ireland",
     "shortname": ":flag_ie:",
@@ -18732,7 +18732,7 @@
     ]
   },
   "flag_il": {
-    "unicode": "1f1ee-1F1F1",
+    "unicode": "1F1EE-1F1F1",
     "unicode_alternates": [],
     "name": "israel",
     "shortname": ":flag_il:",
@@ -18751,7 +18751,7 @@
     ]
   },
   "flag_it": {
-    "unicode": "1f1ee-1F1F9",
+    "unicode": "1F1EE-1F1F9",
     "unicode_alternates": [],
     "name": "italy",
     "shortname": ":flag_it:",
@@ -18769,7 +18769,7 @@
     ]
   },
   "flag_jp": {
-    "unicode": "1f1ef-1F1F5",
+    "unicode": "1F1EF-1F1F5",
     "unicode_alternates": [],
     "name": "japan",
     "shortname": ":flag_jp:",
@@ -18787,7 +18787,7 @@
     ]
   },
   "flag_kr": {
-    "unicode": "1f1f0-1F1F7",
+    "unicode": "1F1F0-1F1F7",
     "unicode_alternates": [],
     "name": "korea",
     "shortname": ":flag_kr:",
@@ -18805,7 +18805,7 @@
     ]
   },
   "flag_mo": {
-    "unicode": "1f1f2-1F1F4",
+    "unicode": "1F1F2-1F1F4",
     "unicode_alternates": [],
     "name": "macau",
     "shortname": ":flag_mo:",
@@ -18823,7 +18823,7 @@
     ]
   },
   "flag_my": {
-    "unicode": "1f1f2-1F1FE",
+    "unicode": "1F1F2-1F1FE",
     "unicode_alternates": [],
     "name": "malaysia",
     "shortname": ":flag_my:",
@@ -18840,7 +18840,7 @@
     ]
   },
   "flag_mx": {
-    "unicode": "1f1f2-1F1FD",
+    "unicode": "1F1F2-1F1FD",
     "unicode_alternates": [],
     "name": "mexico",
     "shortname": ":flag_mx:",
@@ -18857,7 +18857,7 @@
     ]
   },
   "flag_nl": {
-    "unicode": "1f1f3-1F1F1",
+    "unicode": "1F1F3-1F1F1",
     "unicode_alternates": [],
     "name": "the netherlands",
     "shortname": ":flag_nl:",
@@ -18876,7 +18876,7 @@
     ]
   },
   "flag_nz": {
-    "unicode": "1f1f3-1F1FF",
+    "unicode": "1F1F3-1F1FF",
     "unicode_alternates": [],
     "name": "new zealand",
     "shortname": ":flag_nz:",
@@ -18894,7 +18894,7 @@
     ]
   },
   "flag_no": {
-    "unicode": "1f1f3-1F1F4",
+    "unicode": "1F1F3-1F1F4",
     "unicode_alternates": [],
     "name": "norway",
     "shortname": ":flag_no:",
@@ -18912,7 +18912,7 @@
     ]
   },
   "flag_ph": {
-    "unicode": "1f1f5-1F1ED",
+    "unicode": "1F1F5-1F1ED",
     "unicode_alternates": [],
     "name": "the philippines",
     "shortname": ":flag_ph:",
@@ -18930,7 +18930,7 @@
     ]
   },
   "flag_pl": {
-    "unicode": "1f1f5-1F1F1",
+    "unicode": "1F1F5-1F1F1",
     "unicode_alternates": [],
     "name": "poland",
     "shortname": ":flag_pl:",
@@ -18948,7 +18948,7 @@
     ]
   },
   "flag_pt": {
-    "unicode": "1f1f5-1F1F9",
+    "unicode": "1F1F5-1F1F9",
     "unicode_alternates": [],
     "name": "portugal",
     "shortname": ":flag_pt:",
@@ -18965,7 +18965,7 @@
     ]
   },
   "flag_pr": {
-    "unicode": "1f1f5-1F1F7",
+    "unicode": "1F1F5-1F1F7",
     "unicode_alternates": [],
     "name": "puerto rico",
     "shortname": ":flag_pr:",
@@ -18982,7 +18982,7 @@
     ]
   },
   "flag_ru": {
-    "unicode": "1f1f7-1F1FA",
+    "unicode": "1F1F7-1F1FA",
     "unicode_alternates": [],
     "name": "russia",
     "shortname": ":flag_ru:",
@@ -19000,7 +19000,7 @@
     ]
   },
   "flag_sa": {
-    "unicode": "1f1f8-1F1E6",
+    "unicode": "1F1F8-1F1E6",
     "unicode_alternates": [],
     "name": "saudi arabia",
     "shortname": ":flag_sa:",
@@ -19019,7 +19019,7 @@
     ]
   },
   "flag_sg": {
-    "unicode": "1f1f8-1F1EC",
+    "unicode": "1F1F8-1F1EC",
     "unicode_alternates": [],
     "name": "singapore",
     "shortname": ":flag_sg:",
@@ -19036,7 +19036,7 @@
     ]
   },
   "flag_za": {
-    "unicode": "1f1ff-1F1E6",
+    "unicode": "1F1FF-1F1E6",
     "unicode_alternates": [],
     "name": "south africa",
     "shortname": ":flag_za:",
@@ -19052,7 +19052,7 @@
     ]
   },
   "flag_es": {
-    "unicode": "1f1ea-1F1F8",
+    "unicode": "1F1EA-1F1F8",
     "unicode_alternates": [],
     "name": "spain",
     "shortname": ":flag_es:",
@@ -19071,7 +19071,7 @@
     ]
   },
   "flag_se": {
-    "unicode": "1f1f8-1F1EA",
+    "unicode": "1F1F8-1F1EA",
     "unicode_alternates": [],
     "name": "sweden",
     "shortname": ":flag_se:",
@@ -19089,7 +19089,7 @@
     ]
   },
   "flag_ch": {
-    "unicode": "1f1e8-1F1ED",
+    "unicode": "1F1E8-1F1ED",
     "unicode_alternates": [],
     "name": "switzerland",
     "shortname": ":flag_ch:",
@@ -19106,7 +19106,7 @@
     ]
   },
   "flag_tr": {
-    "unicode": "1f1f9-1F1F7",
+    "unicode": "1F1F9-1F1F7",
     "unicode_alternates": [],
     "name": "turkey",
     "shortname": ":flag_tr:",
@@ -19123,7 +19123,7 @@
     ]
   },
   "flag_gb": {
-    "unicode": "1f1ec-1F1E7",
+    "unicode": "1F1EC-1F1E7",
     "unicode_alternates": [],
     "name": "great britain",
     "shortname": ":flag_gb:",
@@ -19144,7 +19144,7 @@
     ]
   },
   "flag_us": {
-    "unicode": "1f1fa-1F1F8",
+    "unicode": "1F1FA-1F1F8",
     "unicode_alternates": [],
     "name": "united states",
     "shortname": ":flag_us:",
@@ -19166,7 +19166,7 @@
     ]
   },
   "flag_ae": {
-    "unicode": "1f1e6-1F1EA",
+    "unicode": "1F1E6-1F1EA",
     "unicode_alternates": [],
     "name": "the united arab emirates",
     "shortname": ":flag_ae:",
@@ -19183,7 +19183,7 @@
     ]
   },
   "flag_vn": {
-    "unicode": "1f1fb-1F1F3",
+    "unicode": "1F1FB-1F1F3",
     "unicode_alternates": [],
     "name": "vietnam",
     "shortname": ":flag_vn:",
@@ -19201,7 +19201,7 @@
     ]
   },
   "flag_af": {
-    "unicode": "1f1e6-1F1EB",
+    "unicode": "1F1E6-1F1EB",
     "unicode_alternates": [],
     "name": "afghanistan",
     "shortname": ":flag_af:",
@@ -19219,7 +19219,7 @@
     ]
   },
   "flag_al": {
-    "unicode": "1f1e6-1F1F1",
+    "unicode": "1F1E6-1F1F1",
     "unicode_alternates": [],
     "name": "albania",
     "shortname": ":flag_al:",
@@ -19237,7 +19237,7 @@
     ]
   },
   "flag_dz": {
-    "unicode": "1f1e9-1F1FF",
+    "unicode": "1F1E9-1F1FF",
     "unicode_alternates": [],
     "name": "algeria",
     "shortname": ":flag_dz:",
@@ -19256,7 +19256,7 @@
     ]
   },
   "flag_ad": {
-    "unicode": "1f1e6-1F1E9",
+    "unicode": "1F1E6-1F1E9",
     "unicode_alternates": [],
     "name": "andorra",
     "shortname": ":flag_ad:",
@@ -19273,7 +19273,7 @@
     ]
   },
   "flag_ao": {
-    "unicode": "1f1e6-1F1F4",
+    "unicode": "1F1E6-1F1F4",
     "unicode_alternates": [],
     "name": "angola",
     "shortname": ":flag_ao:",
@@ -19290,7 +19290,7 @@
     ]
   },
   "flag_ai": {
-    "unicode": "1f1e6-1F1EE",
+    "unicode": "1F1E6-1F1EE",
     "unicode_alternates": [],
     "name": "anguilla",
     "shortname": ":flag_ai:",
@@ -19307,7 +19307,7 @@
     ]
   },
   "flag_ag": {
-    "unicode": "1f1e6-1F1EC",
+    "unicode": "1F1E6-1F1EC",
     "unicode_alternates": [],
     "name": "antigua and barbuda",
     "shortname": ":flag_ag:",
@@ -19324,7 +19324,7 @@
     ]
   },
   "flag_ar": {
-    "unicode": "1f1e6-1F1F7",
+    "unicode": "1F1E6-1F1F7",
     "unicode_alternates": [],
     "name": "argentina",
     "shortname": ":flag_ar:",
@@ -19341,7 +19341,7 @@
     ]
   },
   "flag_am": {
-    "unicode": "1f1e6-1F1F2",
+    "unicode": "1F1E6-1F1F2",
     "unicode_alternates": [],
     "name": "armenia",
     "shortname": ":flag_am:",
@@ -19359,7 +19359,7 @@
     ]
   },
   "flag_aw": {
-    "unicode": "1f1e6-1F1FC",
+    "unicode": "1F1E6-1F1FC",
     "unicode_alternates": [],
     "name": "aruba",
     "shortname": ":flag_aw:",
@@ -19376,7 +19376,7 @@
     ]
   },
   "flag_ac": {
-    "unicode": "1f1e6-1F1E8",
+    "unicode": "1F1E6-1F1E8",
     "unicode_alternates": [],
     "name": "ascension",
     "shortname": ":flag_ac:",
@@ -19393,7 +19393,7 @@
     ]
   },
   "flag_az": {
-    "unicode": "1f1e6-1F1FF",
+    "unicode": "1F1E6-1F1FF",
     "unicode_alternates": [],
     "name": "azerbaijan",
     "shortname": ":flag_az:",
@@ -19411,7 +19411,7 @@
     ]
   },
   "flag_bs": {
-    "unicode": "1f1e7-1F1F8",
+    "unicode": "1F1E7-1F1F8",
     "unicode_alternates": [],
     "name": "the bahamas",
     "shortname": ":flag_bs:",
@@ -19428,7 +19428,7 @@
     ]
   },
   "flag_bh": {
-    "unicode": "1f1e7-1F1ED",
+    "unicode": "1F1E7-1F1ED",
     "unicode_alternates": [],
     "name": "bahrain",
     "shortname": ":flag_bh:",
@@ -19446,7 +19446,7 @@
     ]
   },
   "flag_bd": {
-    "unicode": "1f1e7-1F1E9",
+    "unicode": "1F1E7-1F1E9",
     "unicode_alternates": [],
     "name": "bangladesh",
     "shortname": ":flag_bd:",
@@ -19463,7 +19463,7 @@
     ]
   },
   "flag_bb": {
-    "unicode": "1f1e7-1F1E7",
+    "unicode": "1F1E7-1F1E7",
     "unicode_alternates": [],
     "name": "barbados",
     "shortname": ":flag_bb:",
@@ -19480,7 +19480,7 @@
     ]
   },
   "flag_by": {
-    "unicode": "1f1e7-1F1FE",
+    "unicode": "1F1E7-1F1FE",
     "unicode_alternates": [],
     "name": "belarus",
     "shortname": ":flag_by:",
@@ -19498,7 +19498,7 @@
     ]
   },
   "flag_bz": {
-    "unicode": "1f1e7-1F1FF",
+    "unicode": "1F1E7-1F1FF",
     "unicode_alternates": [],
     "name": "belize",
     "shortname": ":flag_bz:",
@@ -19515,7 +19515,7 @@
     ]
   },
   "flag_bj": {
-    "unicode": "1f1e7-1F1EF",
+    "unicode": "1F1E7-1F1EF",
     "unicode_alternates": [],
     "name": "benin",
     "shortname": ":flag_bj:",
@@ -19532,7 +19532,7 @@
     ]
   },
   "flag_bm": {
-    "unicode": "1f1e7-1F1F2",
+    "unicode": "1F1E7-1F1F2",
     "unicode_alternates": [],
     "name": "bermuda",
     "shortname": ":flag_bm:",
@@ -19549,7 +19549,7 @@
     ]
   },
   "flag_bt": {
-    "unicode": "1f1e7-1F1F9",
+    "unicode": "1F1E7-1F1F9",
     "unicode_alternates": [],
     "name": "bhutan",
     "shortname": ":flag_bt:",
@@ -19566,7 +19566,7 @@
     ]
   },
   "flag_bo": {
-    "unicode": "1f1e7-1F1F4",
+    "unicode": "1F1E7-1F1F4",
     "unicode_alternates": [],
     "name": "bolivia",
     "shortname": ":flag_bo:",
@@ -19583,7 +19583,7 @@
     ]
   },
   "flag_ba": {
-    "unicode": "1f1e7-1F1E6",
+    "unicode": "1F1E7-1F1E6",
     "unicode_alternates": [],
     "name": "bosnia and herzegovina",
     "shortname": ":flag_ba:",
@@ -19601,7 +19601,7 @@
     ]
   },
   "flag_bw": {
-    "unicode": "1f1e7-1F1FC",
+    "unicode": "1F1E7-1F1FC",
     "unicode_alternates": [],
     "name": "botswana",
     "shortname": ":flag_bw:",
@@ -19618,7 +19618,7 @@
     ]
   },
   "flag_bn": {
-    "unicode": "1f1e7-1F1F3",
+    "unicode": "1F1E7-1F1F3",
     "unicode_alternates": [],
     "name": "brunei",
     "shortname": ":flag_bn:",
@@ -19635,7 +19635,7 @@
     ]
   },
   "flag_bg": {
-    "unicode": "1f1e7-1F1EC",
+    "unicode": "1F1E7-1F1EC",
     "unicode_alternates": [],
     "name": "bulgaria",
     "shortname": ":flag_bg:",
@@ -19652,7 +19652,7 @@
     ]
   },
   "flag_bf": {
-    "unicode": "1f1e7-1F1EB",
+    "unicode": "1F1E7-1F1EB",
     "unicode_alternates": [],
     "name": "burkina faso",
     "shortname": ":flag_bf:",
@@ -19669,7 +19669,7 @@
     ]
   },
   "flag_bi": {
-    "unicode": "1f1e7-1F1EE",
+    "unicode": "1F1E7-1F1EE",
     "unicode_alternates": [],
     "name": "burundi",
     "shortname": ":flag_bi:",
@@ -19686,7 +19686,7 @@
     ]
   },
   "flag_kh": {
-    "unicode": "1f1f0-1F1ED",
+    "unicode": "1F1F0-1F1ED",
     "unicode_alternates": [],
     "name": "cambodia",
     "shortname": ":flag_kh:",
@@ -19704,7 +19704,7 @@
     ]
   },
   "flag_cm": {
-    "unicode": "1f1e8-1F1F2",
+    "unicode": "1F1E8-1F1F2",
     "unicode_alternates": [],
     "name": "cameroon",
     "shortname": ":flag_cm:",
@@ -19721,7 +19721,7 @@
     ]
   },
   "flag_cv": {
-    "unicode": "1f1e8-1F1FB",
+    "unicode": "1F1E8-1F1FB",
     "unicode_alternates": [],
     "name": "cape verde",
     "shortname": ":flag_cv:",
@@ -19739,7 +19739,7 @@
     ]
   },
   "flag_ky": {
-    "unicode": "1f1f0-1F1FE",
+    "unicode": "1F1F0-1F1FE",
     "unicode_alternates": [],
     "name": "cayman islands",
     "shortname": ":flag_ky:",
@@ -19756,7 +19756,7 @@
     ]
   },
   "flag_cf": {
-    "unicode": "1f1e8-1F1EB",
+    "unicode": "1F1E8-1F1EB",
     "unicode_alternates": [],
     "name": "central african republic",
     "shortname": ":flag_cf:",
@@ -19773,7 +19773,7 @@
     ]
   },
   "flag_km": {
-    "unicode": "1f1f0-1F1F2",
+    "unicode": "1F1F0-1F1F2",
     "unicode_alternates": [],
     "name": "the comoros",
     "shortname": ":flag_km:",
@@ -19790,7 +19790,7 @@
     ]
   },
   "flag_cd": {
-    "unicode": "1f1e8-1F1E9",
+    "unicode": "1F1E8-1F1E9",
     "unicode_alternates": [],
     "name": "the democratic republic of the congo",
     "shortname": ":flag_cd:",
@@ -19809,7 +19809,7 @@
     ]
   },
   "flag_cg": {
-    "unicode": "1f1e8-1F1EC",
+    "unicode": "1F1E8-1F1EC",
     "unicode_alternates": [],
     "name": "the republic of the congo",
     "shortname": ":flag_cg:",
@@ -19826,7 +19826,7 @@
     ]
   },
   "flag_td": {
-    "unicode": "1f1f9-1F1E9",
+    "unicode": "1F1F9-1F1E9",
     "unicode_alternates": [],
     "name": "chad",
     "shortname": ":flag_td:",
@@ -19844,7 +19844,7 @@
     ]
   },
   "flag_cr": {
-    "unicode": "1f1e8-1F1F7",
+    "unicode": "1F1E8-1F1F7",
     "unicode_alternates": [],
     "name": "costa rica",
     "shortname": ":flag_cr:",
@@ -19861,7 +19861,7 @@
     ]
   },
   "flag_ci": {
-    "unicode": "1f1e8-1F1EE",
+    "unicode": "1F1E8-1F1EE",
     "unicode_alternates": [],
     "name": "cote d'ivoire",
     "shortname": ":flag_ci:",
@@ -19878,7 +19878,7 @@
     ]
   },
   "flag_hr": {
-    "unicode": "1f1ed-1F1F7",
+    "unicode": "1F1ED-1F1F7",
     "unicode_alternates": [],
     "name": "croatia",
     "shortname": ":flag_hr:",
@@ -19896,7 +19896,7 @@
     ]
   },
   "flag_cu": {
-    "unicode": "1f1e8-1F1FA",
+    "unicode": "1F1E8-1F1FA",
     "unicode_alternates": [],
     "name": "cuba",
     "shortname": ":flag_cu:",
@@ -19913,7 +19913,7 @@
     ]
   },
   "flag_cy": {
-    "unicode": "1f1e8-1F1FE",
+    "unicode": "1F1E8-1F1FE",
     "unicode_alternates": [],
     "name": "cyprus",
     "shortname": ":flag_cy:",
@@ -19932,7 +19932,7 @@
     ]
   },
   "flag_cz": {
-    "unicode": "1f1e8-1F1FF",
+    "unicode": "1F1E8-1F1FF",
     "unicode_alternates": [],
     "name": "the czech republic",
     "shortname": ":flag_cz:",
@@ -19950,7 +19950,7 @@
     ]
   },
   "flag_dj": {
-    "unicode": "1f1e9-1F1EF",
+    "unicode": "1F1E9-1F1EF",
     "unicode_alternates": [],
     "name": "djibouti",
     "shortname": ":flag_dj:",
@@ -19967,7 +19967,7 @@
     ]
   },
   "flag_dm": {
-    "unicode": "1f1e9-1F1F2",
+    "unicode": "1F1E9-1F1F2",
     "unicode_alternates": [],
     "name": "dominica",
     "shortname": ":flag_dm:",
@@ -19984,7 +19984,7 @@
     ]
   },
   "flag_do": {
-    "unicode": "1f1e9-1F1F4",
+    "unicode": "1F1E9-1F1F4",
     "unicode_alternates": [],
     "name": "the dominican republic",
     "shortname": ":flag_do:",
@@ -20001,7 +20001,7 @@
     ]
   },
   "flag_tl": {
-    "unicode": "1f1f9-1F1F1",
+    "unicode": "1F1F9-1F1F1",
     "unicode_alternates": [],
     "name": "east timor",
     "shortname": ":flag_tl:",
@@ -20018,7 +20018,7 @@
     ]
   },
   "flag_ec": {
-    "unicode": "1f1ea-1F1E8",
+    "unicode": "1F1EA-1F1E8",
     "unicode_alternates": [],
     "name": "ecuador",
     "shortname": ":flag_ec:",
@@ -20035,7 +20035,7 @@
     ]
   },
   "flag_eg": {
-    "unicode": "1f1ea-1F1EC",
+    "unicode": "1F1EA-1F1EC",
     "unicode_alternates": [],
     "name": "egypt",
     "shortname": ":flag_eg:",
@@ -20053,7 +20053,7 @@
     ]
   },
   "flag_sv": {
-    "unicode": "1f1f8-1F1FB",
+    "unicode": "1F1F8-1F1FB",
     "unicode_alternates": [],
     "name": "el salvador",
     "shortname": ":flag_sv:",
@@ -20070,7 +20070,7 @@
     ]
   },
   "flag_gq": {
-    "unicode": "1f1ec-1F1F6",
+    "unicode": "1F1EC-1F1F6",
     "unicode_alternates": [],
     "name": "equatorial guinea",
     "shortname": ":flag_gq:",
@@ -20088,7 +20088,7 @@
     ]
   },
   "flag_er": {
-    "unicode": "1f1ea-1F1F7",
+    "unicode": "1F1EA-1F1F7",
     "unicode_alternates": [],
     "name": "eritrea",
     "shortname": ":flag_er:",
@@ -20106,7 +20106,7 @@
     ]
   },
   "flag_ee": {
-    "unicode": "1f1ea-1F1EA",
+    "unicode": "1F1EA-1F1EA",
     "unicode_alternates": [],
     "name": "estonia",
     "shortname": ":flag_ee:",
@@ -20124,7 +20124,7 @@
     ]
   },
   "flag_et": {
-    "unicode": "1f1ea-1F1F9",
+    "unicode": "1F1EA-1F1F9",
     "unicode_alternates": [],
     "name": "ethiopia",
     "shortname": ":flag_et:",
@@ -20143,7 +20143,7 @@
     ]
   },
   "flag_fk": {
-    "unicode": "1f1eb-1F1F0",
+    "unicode": "1F1EB-1F1F0",
     "unicode_alternates": [],
     "name": "falkland islands",
     "shortname": ":flag_fk:",
@@ -20161,7 +20161,7 @@
     ]
   },
   "flag_fo": {
-    "unicode": "1f1eb-1F1F4",
+    "unicode": "1F1EB-1F1F4",
     "unicode_alternates": [],
     "name": "faroe islands",
     "shortname": ":flag_fo:",
@@ -20179,7 +20179,7 @@
     ]
   },
   "flag_fj": {
-    "unicode": "1f1eb-1F1EF",
+    "unicode": "1F1EB-1F1EF",
     "unicode_alternates": [],
     "name": "fiji",
     "shortname": ":flag_fj:",
@@ -20196,7 +20196,7 @@
     ]
   },
   "flag_pf": {
-    "unicode": "1f1f5-1F1EB",
+    "unicode": "1F1F5-1F1EB",
     "unicode_alternates": [],
     "name": "french polynesia",
     "shortname": ":flag_pf:",
@@ -20215,7 +20215,7 @@
     ]
   },
   "flag_ga": {
-    "unicode": "1f1ec-1F1E6",
+    "unicode": "1F1EC-1F1E6",
     "unicode_alternates": [],
     "name": "gabon",
     "shortname": ":flag_ga:",
@@ -20232,7 +20232,7 @@
     ]
   },
   "flag_gm": {
-    "unicode": "1f1ec-1F1F2",
+    "unicode": "1F1EC-1F1F2",
     "unicode_alternates": [],
     "name": "the gambia",
     "shortname": ":flag_gm:",
@@ -20249,7 +20249,7 @@
     ]
   },
   "flag_ge": {
-    "unicode": "1f1ec-1F1EA",
+    "unicode": "1F1EC-1F1EA",
     "unicode_alternates": [],
     "name": "georgia",
     "shortname": ":flag_ge:",
@@ -20268,7 +20268,7 @@
     ]
   },
   "flag_gh": {
-    "unicode": "1f1ec-1F1ED",
+    "unicode": "1F1EC-1F1ED",
     "unicode_alternates": [],
     "name": "ghana",
     "shortname": ":flag_gh:",
@@ -20285,7 +20285,7 @@
     ]
   },
   "flag_gi": {
-    "unicode": "1f1ec-1F1EE",
+    "unicode": "1F1EC-1F1EE",
     "unicode_alternates": [],
     "name": "gibraltar",
     "shortname": ":flag_gi:",
@@ -20302,7 +20302,7 @@
     ]
   },
   "flag_gr": {
-    "unicode": "1f1ec-1F1F7",
+    "unicode": "1F1EC-1F1F7",
     "unicode_alternates": [],
     "name": "greece",
     "shortname": ":flag_gr:",
@@ -20321,7 +20321,7 @@
     ]
   },
   "flag_gl": {
-    "unicode": "1f1ec-1F1F1",
+    "unicode": "1F1EC-1F1F1",
     "unicode_alternates": [],
     "name": "greenland",
     "shortname": ":flag_gl:",
@@ -20339,7 +20339,7 @@
     ]
   },
   "flag_gd": {
-    "unicode": "1f1ec-1F1E9",
+    "unicode": "1F1EC-1F1E9",
     "unicode_alternates": [],
     "name": "grenada",
     "shortname": ":flag_gd:",
@@ -20356,7 +20356,7 @@
     ]
   },
   "flag_gu": {
-    "unicode": "1f1ec-1F1FA",
+    "unicode": "1F1EC-1F1FA",
     "unicode_alternates": [],
     "name": "guam",
     "shortname": ":flag_gu:",
@@ -20373,7 +20373,7 @@
     ]
   },
   "flag_gt": {
-    "unicode": "1f1ec-1F1F9",
+    "unicode": "1F1EC-1F1F9",
     "unicode_alternates": [],
     "name": "guatemala",
     "shortname": ":flag_gt:",
@@ -20390,7 +20390,7 @@
     ]
   },
   "flag_gn": {
-    "unicode": "1f1ec-1F1F3",
+    "unicode": "1F1EC-1F1F3",
     "unicode_alternates": [],
     "name": "guinea",
     "shortname": ":flag_gn:",
@@ -20408,7 +20408,7 @@
     ]
   },
   "flag_gw": {
-    "unicode": "1f1ec-1F1FC",
+    "unicode": "1F1EC-1F1FC",
     "unicode_alternates": [],
     "name": "guinea-bissau",
     "shortname": ":flag_gw:",
@@ -20427,7 +20427,7 @@
     ]
   },
   "flag_gy": {
-    "unicode": "1f1ec-1F1FE",
+    "unicode": "1F1EC-1F1FE",
     "unicode_alternates": [],
     "name": "guyana",
     "shortname": ":flag_gy:",
@@ -20444,7 +20444,7 @@
     ]
   },
   "flag_ht": {
-    "unicode": "1f1ed-1F1F9",
+    "unicode": "1F1ED-1F1F9",
     "unicode_alternates": [],
     "name": "haiti",
     "shortname": ":flag_ht:",
@@ -20461,7 +20461,7 @@
     ]
   },
   "flag_hn": {
-    "unicode": "1f1ed-1F1F3",
+    "unicode": "1F1ED-1F1F3",
     "unicode_alternates": [],
     "name": "honduras",
     "shortname": ":flag_hn:",
@@ -20478,7 +20478,7 @@
     ]
   },
   "flag_hu": {
-    "unicode": "1f1ed-1F1FA",
+    "unicode": "1F1ED-1F1FA",
     "unicode_alternates": [],
     "name": "hungary",
     "shortname": ":flag_hu:",
@@ -20496,7 +20496,7 @@
     ]
   },
   "flag_is": {
-    "unicode": "1f1ee-1F1F8",
+    "unicode": "1F1EE-1F1F8",
     "unicode_alternates": [],
     "name": "iceland",
     "shortname": ":flag_is:",
@@ -20514,7 +20514,7 @@
     ]
   },
   "flag_ir": {
-    "unicode": "1f1ee-1F1F7",
+    "unicode": "1F1EE-1F1F7",
     "unicode_alternates": [],
     "name": "iran",
     "shortname": ":flag_ir:",
@@ -20531,7 +20531,7 @@
     ]
   },
   "flag_iq": {
-    "unicode": "1f1ee-1F1F6",
+    "unicode": "1F1EE-1F1F6",
     "unicode_alternates": [],
     "name": "iraq",
     "shortname": ":flag_iq:",
@@ -20548,7 +20548,7 @@
     ]
   },
   "flag_jm": {
-    "unicode": "1f1ef-1F1F2",
+    "unicode": "1F1EF-1F1F2",
     "unicode_alternates": [],
     "name": "jamaica",
     "shortname": ":flag_jm:",
@@ -20565,7 +20565,7 @@
     ]
   },
   "flag_je": {
-    "unicode": "1f1ef-1F1EA",
+    "unicode": "1F1EF-1F1EA",
     "unicode_alternates": [],
     "name": "jersey",
     "shortname": ":flag_je:",
@@ -20582,7 +20582,7 @@
     ]
   },
   "flag_jo": {
-    "unicode": "1f1ef-1F1F4",
+    "unicode": "1F1EF-1F1F4",
     "unicode_alternates": [],
     "name": "jordan",
     "shortname": ":flag_jo:",
@@ -20600,7 +20600,7 @@
     ]
   },
   "flag_kz": {
-    "unicode": "1f1f0-1F1FF",
+    "unicode": "1F1F0-1F1FF",
     "unicode_alternates": [],
     "name": "kazakhstan",
     "shortname": ":flag_kz:",
@@ -20618,7 +20618,7 @@
     ]
   },
   "flag_ke": {
-    "unicode": "1f1f0-1F1EA",
+    "unicode": "1F1F0-1F1EA",
     "unicode_alternates": [],
     "name": "kenya",
     "shortname": ":flag_ke:",
@@ -20635,7 +20635,7 @@
     ]
   },
   "flag_ki": {
-    "unicode": "1f1f0-1F1EE",
+    "unicode": "1F1F0-1F1EE",
     "unicode_alternates": [],
     "name": "kiribati",
     "shortname": ":flag_ki:",
@@ -20654,7 +20654,7 @@
     ]
   },
   "flag_xk": {
-    "unicode": "1f1fd-1F1F0",
+    "unicode": "1F1FD-1F1F0",
     "unicode_alternates": [],
     "name": "kosovo",
     "shortname": ":flag_xk:",
@@ -20671,7 +20671,7 @@
     ]
   },
   "flag_kw": {
-    "unicode": "1f1f0-1F1FC",
+    "unicode": "1F1F0-1F1FC",
     "unicode_alternates": [],
     "name": "kuwait",
     "shortname": ":flag_kw:",
@@ -20689,7 +20689,7 @@
     ]
   },
   "flag_kg": {
-    "unicode": "1f1f0-1F1EC",
+    "unicode": "1F1F0-1F1EC",
     "unicode_alternates": [],
     "name": "kyrgyzstan",
     "shortname": ":flag_kg:",
@@ -20707,7 +20707,7 @@
     ]
   },
   "flag_la": {
-    "unicode": "1f1f1-1F1E6",
+    "unicode": "1F1F1-1F1E6",
     "unicode_alternates": [],
     "name": "laos",
     "shortname": ":flag_la:",
@@ -20724,7 +20724,7 @@
     ]
   },
   "flag_lv": {
-    "unicode": "1f1f1-1F1FB",
+    "unicode": "1F1F1-1F1FB",
     "unicode_alternates": [],
     "name": "latvia",
     "shortname": ":flag_lv:",
@@ -20742,7 +20742,7 @@
     ]
   },
   "flag_lb": {
-    "unicode": "1f1f1-1F1E7",
+    "unicode": "1F1F1-1F1E7",
     "unicode_alternates": [],
     "name": "lebanon",
     "shortname": ":flag_lb:",
@@ -20760,7 +20760,7 @@
     ]
   },
   "flag_ls": {
-    "unicode": "1f1f1-1F1F8",
+    "unicode": "1F1F1-1F1F8",
     "unicode_alternates": [],
     "name": "lesotho",
     "shortname": ":flag_ls:",
@@ -20777,7 +20777,7 @@
     ]
   },
   "flag_lr": {
-    "unicode": "1f1f1-1F1F7",
+    "unicode": "1F1F1-1F1F7",
     "unicode_alternates": [],
     "name": "liberia",
     "shortname": ":flag_lr:",
@@ -20794,7 +20794,7 @@
     ]
   },
   "flag_ly": {
-    "unicode": "1f1f1-1F1FE",
+    "unicode": "1F1F1-1F1FE",
     "unicode_alternates": [],
     "name": "libya",
     "shortname": ":flag_ly:",
@@ -20812,7 +20812,7 @@
     ]
   },
   "flag_li": {
-    "unicode": "1f1f1-1F1EE",
+    "unicode": "1F1F1-1F1EE",
     "unicode_alternates": [],
     "name": "liechtenstein",
     "shortname": ":flag_li:",
@@ -20829,7 +20829,7 @@
     ]
   },
   "flag_lt": {
-    "unicode": "1f1f1-1F1F9",
+    "unicode": "1F1F1-1F1F9",
     "unicode_alternates": [],
     "name": "lithuania",
     "shortname": ":flag_lt:",
@@ -20847,7 +20847,7 @@
     ]
   },
   "flag_lu": {
-    "unicode": "1f1f1-1F1FA",
+    "unicode": "1F1F1-1F1FA",
     "unicode_alternates": [],
     "name": "luxembourg",
     "shortname": ":flag_lu:",
@@ -20866,7 +20866,7 @@
     ]
   },
   "flag_mk": {
-    "unicode": "1f1f2-1F1F0",
+    "unicode": "1F1F2-1F1F0",
     "unicode_alternates": [],
     "name": "macedonia",
     "shortname": ":flag_mk:",
@@ -20883,7 +20883,7 @@
     ]
   },
   "flag_mg": {
-    "unicode": "1f1f2-1F1EC",
+    "unicode": "1F1F2-1F1EC",
     "unicode_alternates": [],
     "name": "madagascar",
     "shortname": ":flag_mg:",
@@ -20900,7 +20900,7 @@
     ]
   },
   "flag_mw": {
-    "unicode": "1f1f2-1F1FC",
+    "unicode": "1F1F2-1F1FC",
     "unicode_alternates": [],
     "name": "malawi",
     "shortname": ":flag_mw:",
@@ -20917,7 +20917,7 @@
     ]
   },
   "flag_mv": {
-    "unicode": "1f1f2-1F1FB",
+    "unicode": "1F1F2-1F1FB",
     "unicode_alternates": [],
     "name": "maldives",
     "shortname": ":flag_mv:",
@@ -20935,7 +20935,7 @@
     ]
   },
   "flag_ml": {
-    "unicode": "1f1f2-1F1F1",
+    "unicode": "1F1F2-1F1F1",
     "unicode_alternates": [],
     "name": "mali",
     "shortname": ":flag_ml:",
@@ -20952,7 +20952,7 @@
     ]
   },
   "flag_mt": {
-    "unicode": "1f1f2-1F1F9",
+    "unicode": "1F1F2-1F1F9",
     "unicode_alternates": [],
     "name": "malta",
     "shortname": ":flag_mt:",
@@ -20969,7 +20969,7 @@
     ]
   },
   "flag_mh": {
-    "unicode": "1f1f2-1F1ED",
+    "unicode": "1F1F2-1F1ED",
     "unicode_alternates": [],
     "name": "the marshall islands",
     "shortname": ":flag_mh:",
@@ -20986,7 +20986,7 @@
     ]
   },
   "flag_mr": {
-    "unicode": "1f1f2-1F1F7",
+    "unicode": "1F1F2-1F1F7",
     "unicode_alternates": [],
     "name": "mauritania",
     "shortname": ":flag_mr:",
@@ -21004,7 +21004,7 @@
     ]
   },
   "flag_mu": {
-    "unicode": "1f1f2-1F1FA",
+    "unicode": "1F1F2-1F1FA",
     "unicode_alternates": [],
     "name": "mauritius",
     "shortname": ":flag_mu:",
@@ -21021,7 +21021,7 @@
     ]
   },
   "flag_fm": {
-    "unicode": "1f1eb-1F1F2",
+    "unicode": "1F1EB-1F1F2",
     "unicode_alternates": [],
     "name": "micronesia",
     "shortname": ":flag_fm:",
@@ -21038,7 +21038,7 @@
     ]
   },
   "flag_md": {
-    "unicode": "1f1f2-1F1E9",
+    "unicode": "1F1F2-1F1E9",
     "unicode_alternates": [],
     "name": "moldova",
     "shortname": ":flag_md:",
@@ -21055,7 +21055,7 @@
     ]
   },
   "flag_mc": {
-    "unicode": "1f1f2-1F1E8",
+    "unicode": "1F1F2-1F1E8",
     "unicode_alternates": [],
     "name": "monaco",
     "shortname": ":flag_mc:",
@@ -21072,7 +21072,7 @@
     ]
   },
   "flag_mn": {
-    "unicode": "1f1f2-1F1F3",
+    "unicode": "1F1F2-1F1F3",
     "unicode_alternates": [],
     "name": "mongolia",
     "shortname": ":flag_mn:",
@@ -21090,7 +21090,7 @@
     ]
   },
   "flag_me": {
-    "unicode": "1f1f2-1F1EA",
+    "unicode": "1F1F2-1F1EA",
     "unicode_alternates": [],
     "name": "montenegro",
     "shortname": ":flag_me:",
@@ -21108,7 +21108,7 @@
     ]
   },
   "flag_ms": {
-    "unicode": "1f1f2-1F1F8",
+    "unicode": "1F1F2-1F1F8",
     "unicode_alternates": [],
     "name": "montserrat",
     "shortname": ":flag_ms:",
@@ -21125,7 +21125,7 @@
     ]
   },
   "flag_ma": {
-    "unicode": "1f1f2-1F1E6",
+    "unicode": "1F1F2-1F1E6",
     "unicode_alternates": [],
     "name": "morocco",
     "shortname": ":flag_ma:",
@@ -21143,7 +21143,7 @@
     ]
   },
   "flag_mz": {
-    "unicode": "1f1f2-1F1FF",
+    "unicode": "1F1F2-1F1FF",
     "unicode_alternates": [],
     "name": "mozambique",
     "shortname": ":flag_mz:",
@@ -21161,7 +21161,7 @@
     ]
   },
   "flag_mm": {
-    "unicode": "1f1f2-1F1F2",
+    "unicode": "1F1F2-1F1F2",
     "unicode_alternates": [],
     "name": "myanmar",
     "shortname": ":flag_mm:",
@@ -21179,7 +21179,7 @@
     ]
   },
   "flag_na": {
-    "unicode": "1f1f3-1F1E6",
+    "unicode": "1F1F3-1F1E6",
     "unicode_alternates": [],
     "name": "namibia",
     "shortname": ":flag_na:",
@@ -21196,7 +21196,7 @@
     ]
   },
   "flag_nr": {
-    "unicode": "1f1f3-1F1F7",
+    "unicode": "1F1F3-1F1F7",
     "unicode_alternates": [],
     "name": "nauru",
     "shortname": ":flag_nr:",
@@ -21213,7 +21213,7 @@
     ]
   },
   "flag_np": {
-    "unicode": "1f1f3-1F1F5",
+    "unicode": "1F1F3-1F1F5",
     "unicode_alternates": [],
     "name": "nepal",
     "shortname": ":flag_np:",
@@ -21230,7 +21230,7 @@
     ]
   },
   "flag_nc": {
-    "unicode": "1f1f3-1F1E8",
+    "unicode": "1F1F3-1F1E8",
     "unicode_alternates": [],
     "name": "new caledonia",
     "shortname": ":flag_nc:",
@@ -21250,7 +21250,7 @@
     ]
   },
   "flag_ni": {
-    "unicode": "1f1f3-1F1EE",
+    "unicode": "1F1F3-1F1EE",
     "unicode_alternates": [],
     "name": "nicaragua",
     "shortname": ":flag_ni:",
@@ -21267,7 +21267,7 @@
     ]
   },
   "flag_ne": {
-    "unicode": "1f1f3-1F1EA",
+    "unicode": "1F1F3-1F1EA",
     "unicode_alternates": [],
     "name": "niger",
     "shortname": ":flag_ne:",
@@ -21284,7 +21284,7 @@
     ]
   },
   "flag_ng": {
-    "unicode": "1f1f3-1F1EC",
+    "unicode": "1F1F3-1F1EC",
     "unicode_alternates": [],
     "name": "nigeria",
     "shortname": ":flag_ng:",
@@ -21301,7 +21301,7 @@
     ]
   },
   "flag_nu": {
-    "unicode": "1f1f3-1F1FA",
+    "unicode": "1F1F3-1F1FA",
     "unicode_alternates": [],
     "name": "niue",
     "shortname": ":flag_nu:",
@@ -21318,7 +21318,7 @@
     ]
   },
   "flag_kp": {
-    "unicode": "1f1f0-1F1F5",
+    "unicode": "1F1F0-1F1F5",
     "unicode_alternates": [],
     "name": "north korea",
     "shortname": ":flag_kp:",
@@ -21335,7 +21335,7 @@
     ]
   },
   "flag_om": {
-    "unicode": "1f1f4-1F1F2",
+    "unicode": "1F1F4-1F1F2",
     "unicode_alternates": [],
     "name": "oman",
     "shortname": ":flag_om:",
@@ -21353,7 +21353,7 @@
     ]
   },
   "flag_pk": {
-    "unicode": "1f1f5-1F1F0",
+    "unicode": "1F1F5-1F1F0",
     "unicode_alternates": [],
     "name": "pakistan",
     "shortname": ":flag_pk:",
@@ -21370,7 +21370,7 @@
     ]
   },
   "flag_pw": {
-    "unicode": "1f1f5-1F1FC",
+    "unicode": "1F1F5-1F1FC",
     "unicode_alternates": [],
     "name": "palau",
     "shortname": ":flag_pw:",
@@ -21388,7 +21388,7 @@
     ]
   },
   "flag_ps": {
-    "unicode": "1f1f5-1F1F8",
+    "unicode": "1F1F5-1F1F8",
     "unicode_alternates": [],
     "name": "palestinian authority",
     "shortname": ":flag_ps:",
@@ -21405,7 +21405,7 @@
     ]
   },
   "flag_pa": {
-    "unicode": "1f1f5-1F1E6",
+    "unicode": "1F1F5-1F1E6",
     "unicode_alternates": [],
     "name": "panama",
     "shortname": ":flag_pa:",
@@ -21422,7 +21422,7 @@
     ]
   },
   "flag_pg": {
-    "unicode": "1f1f5-1F1EC",
+    "unicode": "1F1F5-1F1EC",
     "unicode_alternates": [],
     "name": "papua new guinea",
     "shortname": ":flag_pg:",
@@ -21440,7 +21440,7 @@
     ]
   },
   "flag_py": {
-    "unicode": "1f1f5-1F1FE",
+    "unicode": "1F1F5-1F1FE",
     "unicode_alternates": [],
     "name": "paraguay",
     "shortname": ":flag_py:",
@@ -21457,7 +21457,7 @@
     ]
   },
   "flag_pe": {
-    "unicode": "1f1f5-1F1EA",
+    "unicode": "1F1F5-1F1EA",
     "unicode_alternates": [],
     "name": "peru",
     "shortname": ":flag_pe:",
@@ -21474,7 +21474,7 @@
     ]
   },
   "flag_qa": {
-    "unicode": "1f1f6-1F1E6",
+    "unicode": "1F1F6-1F1E6",
     "unicode_alternates": [],
     "name": "qatar",
     "shortname": ":flag_qa:",
@@ -21492,7 +21492,7 @@
     ]
   },
   "flag_ro": {
-    "unicode": "1f1f7-1F1F4",
+    "unicode": "1F1F7-1F1F4",
     "unicode_alternates": [],
     "name": "romania",
     "shortname": ":flag_ro:",
@@ -21509,7 +21509,7 @@
     ]
   },
   "flag_rw": {
-    "unicode": "1f1f7-1F1FC",
+    "unicode": "1F1F7-1F1FC",
     "unicode_alternates": [],
     "name": "rwanda",
     "shortname": ":flag_rw:",
@@ -21526,7 +21526,7 @@
     ]
   },
   "flag_sh": {
-    "unicode": "1f1f8-1F1ED",
+    "unicode": "1F1F8-1F1ED",
     "unicode_alternates": [],
     "name": "saint helena",
     "shortname": ":flag_sh:",
@@ -21543,7 +21543,7 @@
     ]
   },
   "flag_kn": {
-    "unicode": "1f1f0-1F1F3",
+    "unicode": "1F1F0-1F1F3",
     "unicode_alternates": [],
     "name": "saint kitts and nevis",
     "shortname": ":flag_kn:",
@@ -21560,7 +21560,7 @@
     ]
   },
   "flag_lc": {
-    "unicode": "1f1f1-1F1E8",
+    "unicode": "1F1F1-1F1E8",
     "unicode_alternates": [],
     "name": "saint lucia",
     "shortname": ":flag_lc:",
@@ -21577,7 +21577,7 @@
     ]
   },
   "flag_vc": {
-    "unicode": "1f1fb-1F1E8",
+    "unicode": "1F1FB-1F1E8",
     "unicode_alternates": [],
     "name": "saint vincent and the grenadines",
     "shortname": ":flag_vc:",
@@ -21594,7 +21594,7 @@
     ]
   },
   "flag_ws": {
-    "unicode": "1f1fc-1F1F8",
+    "unicode": "1F1FC-1F1F8",
     "unicode_alternates": [],
     "name": "samoa",
     "shortname": ":flag_ws:",
@@ -21612,7 +21612,7 @@
     ]
   },
   "flag_sm": {
-    "unicode": "1f1f8-1F1F2",
+    "unicode": "1F1F8-1F1F2",
     "unicode_alternates": [],
     "name": "san marino",
     "shortname": ":flag_sm:",
@@ -21629,7 +21629,7 @@
     ]
   },
   "flag_st": {
-    "unicode": "1f1f8-1F1F9",
+    "unicode": "1F1F8-1F1F9",
     "unicode_alternates": [],
     "name": "sao tome and principe",
     "shortname": ":flag_st:",
@@ -21647,7 +21647,7 @@
     ]
   },
   "flag_sn": {
-    "unicode": "1f1f8-1F1F3",
+    "unicode": "1F1F8-1F1F3",
     "unicode_alternates": [],
     "name": "senegal",
     "shortname": ":flag_sn:",
@@ -21664,7 +21664,7 @@
     ]
   },
   "flag_rs": {
-    "unicode": "1f1f7-1F1F8",
+    "unicode": "1F1F7-1F1F8",
     "unicode_alternates": [],
     "name": "serbia",
     "shortname": ":flag_rs:",
@@ -21682,7 +21682,7 @@
     ]
   },
   "flag_sc": {
-    "unicode": "1f1f8-1F1E8",
+    "unicode": "1F1F8-1F1E8",
     "unicode_alternates": [],
     "name": "the seychelles",
     "shortname": ":flag_sc:",
@@ -21700,7 +21700,7 @@
     ]
   },
   "flag_sl": {
-    "unicode": "1f1f8-1F1F1",
+    "unicode": "1F1F8-1F1F1",
     "unicode_alternates": [],
     "name": "sierra leone",
     "shortname": ":flag_sl:",
@@ -21717,7 +21717,7 @@
     ]
   },
   "flag_sk": {
-    "unicode": "1f1f8-1F1F0",
+    "unicode": "1F1F8-1F1F0",
     "unicode_alternates": [],
     "name": "slovakia",
     "shortname": ":flag_sk:",
@@ -21734,7 +21734,7 @@
     ]
   },
   "flag_si": {
-    "unicode": "1f1f8-1F1EE",
+    "unicode": "1F1F8-1F1EE",
     "unicode_alternates": [],
     "name": "slovenia",
     "shortname": ":flag_si:",
@@ -21752,7 +21752,7 @@
     ]
   },
   "flag_sb": {
-    "unicode": "1f1f8-1F1E7",
+    "unicode": "1F1F8-1F1E7",
     "unicode_alternates": [],
     "name": "the solomon islands",
     "shortname": ":flag_sb:",
@@ -21769,7 +21769,7 @@
     ]
   },
   "flag_so": {
-    "unicode": "1f1f8-1F1F4",
+    "unicode": "1F1F8-1F1F4",
     "unicode_alternates": [],
     "name": "somalia",
     "shortname": ":flag_so:",
@@ -21786,7 +21786,7 @@
     ]
   },
   "flag_lk": {
-    "unicode": "1f1f1-1F1F0",
+    "unicode": "1F1F1-1F1F0",
     "unicode_alternates": [],
     "name": "sri lanka",
     "shortname": ":flag_lk:",
@@ -21803,7 +21803,7 @@
     ]
   },
   "flag_sd": {
-    "unicode": "1f1f8-1F1E9",
+    "unicode": "1F1F8-1F1E9",
     "unicode_alternates": [],
     "name": "sudan",
     "shortname": ":flag_sd:",
@@ -21821,7 +21821,7 @@
     ]
   },
   "flag_sr": {
-    "unicode": "1f1f8-1F1F7",
+    "unicode": "1F1F8-1F1F7",
     "unicode_alternates": [],
     "name": "suriname",
     "shortname": ":flag_sr:",
@@ -21838,7 +21838,7 @@
     ]
   },
   "flag_sz": {
-    "unicode": "1f1f8-1F1FF",
+    "unicode": "1F1F8-1F1FF",
     "unicode_alternates": [],
     "name": "swaziland",
     "shortname": ":flag_sz:",
@@ -21855,7 +21855,7 @@
     ]
   },
   "flag_sy": {
-    "unicode": "1f1f8-1F1FE",
+    "unicode": "1F1F8-1F1FE",
     "unicode_alternates": [],
     "name": "syria",
     "shortname": ":flag_sy:",
@@ -21872,7 +21872,7 @@
     ]
   },
   "flag_tw": {
-    "unicode": "1f1f9-1F1FC",
+    "unicode": "1F1F9-1F1FC",
     "unicode_alternates": [],
     "name": "the republic of china",
     "shortname": ":flag_tw:",
@@ -21890,7 +21890,7 @@
     ]
   },
   "flag_tj": {
-    "unicode": "1f1f9-1F1EF",
+    "unicode": "1F1F9-1F1EF",
     "unicode_alternates": [],
     "name": "tajikistan",
     "shortname": ":flag_tj:",
@@ -21908,7 +21908,7 @@
     ]
   },
   "flag_tz": {
-    "unicode": "1f1f9-1F1FF",
+    "unicode": "1F1F9-1F1FF",
     "unicode_alternates": [],
     "name": "tanzania",
     "shortname": ":flag_tz:",
@@ -21925,7 +21925,7 @@
     ]
   },
   "flag_th": {
-    "unicode": "1f1f9-1F1ED",
+    "unicode": "1F1F9-1F1ED",
     "unicode_alternates": [],
     "name": "thailand",
     "shortname": ":flag_th:",
@@ -21943,7 +21943,7 @@
     ]
   },
   "flag_tg": {
-    "unicode": "1f1f9-1F1EC",
+    "unicode": "1F1F9-1F1EC",
     "unicode_alternates": [],
     "name": "togo",
     "shortname": ":flag_tg:",
@@ -21961,7 +21961,7 @@
     ]
   },
   "flag_to": {
-    "unicode": "1f1f9-1F1F4",
+    "unicode": "1F1F9-1F1F4",
     "unicode_alternates": [],
     "name": "tonga",
     "shortname": ":flag_to:",
@@ -21978,7 +21978,7 @@
     ]
   },
   "flag_tt": {
-    "unicode": "1f1f9-1F1F9",
+    "unicode": "1F1F9-1F1F9",
     "unicode_alternates": [],
     "name": "trinidad and tobago",
     "shortname": ":flag_tt:",
@@ -21995,7 +21995,7 @@
     ]
   },
   "flag_tn": {
-    "unicode": "1f1f9-1F1F3",
+    "unicode": "1F1F9-1F1F3",
     "unicode_alternates": [],
     "name": "tunisia",
     "shortname": ":flag_tn:",
@@ -22013,7 +22013,7 @@
     ]
   },
   "flag_tm": {
-    "unicode": "1f1f9-1F1F2",
+    "unicode": "1F1F9-1F1F2",
     "unicode_alternates": [],
     "name": "turkmenistan",
     "shortname": ":flag_tm:",
@@ -22030,7 +22030,7 @@
     ]
   },
   "flag_tv": {
-    "unicode": "1f1f9-1F1FB",
+    "unicode": "1F1F9-1F1FB",
     "unicode_alternates": [],
     "name": "tuvalu",
     "shortname": ":flag_tv:",
@@ -22047,7 +22047,7 @@
     ]
   },
   "flag_vi": {
-    "unicode": "1f1fb-1F1EE",
+    "unicode": "1F1FB-1F1EE",
     "unicode_alternates": [],
     "name": "u.s. virgin islands",
     "shortname": ":flag_vi:",
@@ -22064,7 +22064,7 @@
     ]
   },
   "flag_ug": {
-    "unicode": "1f1fa-1F1EC",
+    "unicode": "1F1FA-1F1EC",
     "unicode_alternates": [],
     "name": "uganda",
     "shortname": ":flag_ug:",
@@ -22081,7 +22081,7 @@
     ]
   },
   "flag_ua": {
-    "unicode": "1f1fa-1F1E6",
+    "unicode": "1F1FA-1F1E6",
     "unicode_alternates": [],
     "name": "ukraine",
     "shortname": ":flag_ua:",
@@ -22099,7 +22099,7 @@
     ]
   },
   "flag_uy": {
-    "unicode": "1f1fa-1F1FE",
+    "unicode": "1F1FA-1F1FE",
     "unicode_alternates": [],
     "name": "uruguay",
     "shortname": ":flag_uy:",
@@ -22116,7 +22116,7 @@
     ]
   },
   "flag_uz": {
-    "unicode": "1f1fa-1F1FF",
+    "unicode": "1F1FA-1F1FF",
     "unicode_alternates": [],
     "name": "uzbekistan",
     "shortname": ":flag_uz:",
@@ -22134,7 +22134,7 @@
     ]
   },
   "flag_vu": {
-    "unicode": "1f1fb-1F1FA",
+    "unicode": "1F1FB-1F1FA",
     "unicode_alternates": [],
     "name": "vanuatu",
     "shortname": ":flag_vu:",
@@ -22151,7 +22151,7 @@
     ]
   },
   "flag_va": {
-    "unicode": "1f1fb-1F1E6",
+    "unicode": "1F1FB-1F1E6",
     "unicode_alternates": [],
     "name": "the vatican city",
     "shortname": ":flag_va:",
@@ -22168,7 +22168,7 @@
     ]
   },
   "flag_ve": {
-    "unicode": "1f1fb-1F1EA",
+    "unicode": "1F1FB-1F1EA",
     "unicode_alternates": [],
     "name": "venezuela",
     "shortname": ":flag_ve:",
@@ -22185,7 +22185,7 @@
     ]
   },
   "flag_wf": {
-    "unicode": "1f1fc-1F1EB",
+    "unicode": "1F1FC-1F1EB",
     "unicode_alternates": [],
     "name": "wallis and futuna",
     "shortname": ":flag_wf:",
@@ -22202,7 +22202,7 @@
     ]
   },
   "flag_eh": {
-    "unicode": "1f1ea-1F1ED",
+    "unicode": "1F1EA-1F1ED",
     "unicode_alternates": [],
     "name": "western sahara",
     "shortname": ":flag_eh:",
@@ -22222,7 +22222,7 @@
     ]
   },
   "flag_ye": {
-    "unicode": "1f1fe-1F1EA",
+    "unicode": "1F1FE-1F1EA",
     "unicode_alternates": [],
     "name": "yemen",
     "shortname": ":flag_ye:",
@@ -22240,7 +22240,7 @@
     ]
   },
   "flag_zm": {
-    "unicode": "1f1ff-1F1F2",
+    "unicode": "1F1FF-1F1F2",
     "unicode_alternates": [],
     "name": "zambia",
     "shortname": ":flag_zm:",
@@ -22257,7 +22257,7 @@
     ]
   },
   "flag_zw": {
-    "unicode": "1f1ff-1F1FC",
+    "unicode": "1F1FF-1F1FC",
     "unicode_alternates": [],
     "name": "zimbabwe",
     "shortname": ":flag_zw:",

--- a/emojimap.json
+++ b/emojimap.json
@@ -1,6 +1,6 @@
 {
   "grinning": {
-    "unicode": "1F600",
+    "unicode": "1f600",
     "unicode_alternates": [],
     "name": "grinning face",
     "shortname": ":grinning:",
@@ -18,7 +18,7 @@
     ]
   },
   "grin": {
-    "unicode": "1F601",
+    "unicode": "1f601",
     "unicode_alternates": [],
     "name": "grinning face with smiling eyes",
     "shortname": ":grin:",
@@ -35,7 +35,7 @@
     ]
   },
   "joy": {
-    "unicode": "1F602",
+    "unicode": "1f602",
     "unicode_alternates": [],
     "name": "face with tears of joy",
     "shortname": ":joy:",
@@ -54,7 +54,7 @@
     ]
   },
   "smiley": {
-    "unicode": "1F603",
+    "unicode": "1f603",
     "unicode_alternates": [],
     "name": "smiling face with open mouth",
     "shortname": ":smiley:",
@@ -75,7 +75,7 @@
     ]
   },
   "smile": {
-    "unicode": "1F604",
+    "unicode": "1f604",
     "unicode_alternates": [],
     "name": "smiling face with open mouth and smiling eyes",
     "shortname": ":smile:",
@@ -100,7 +100,7 @@
     ]
   },
   "sweat_smile": {
-    "unicode": "1F605",
+    "unicode": "1f605",
     "unicode_alternates": [],
     "name": "smiling face with open mouth and cold sweat",
     "shortname": ":sweat_smile:",
@@ -123,7 +123,7 @@
     ]
   },
   "laughing": {
-    "unicode": "1F606",
+    "unicode": "1f606",
     "unicode_alternates": [],
     "name": "smiling face with open mouth and tightly-closed eyes",
     "shortname": ":laughing:",
@@ -147,7 +147,7 @@
     ]
   },
   "innocent": {
-    "unicode": "1F607",
+    "unicode": "1f607",
     "unicode_alternates": [],
     "name": "smiling face with halo",
     "shortname": ":innocent:",
@@ -177,7 +177,7 @@
     ]
   },
   "smiling_imp": {
-    "unicode": "1F608",
+    "unicode": "1f608",
     "unicode_alternates": [],
     "name": "smiling face with horns",
     "shortname": ":smiling_imp:",
@@ -193,7 +193,7 @@
     ]
   },
   "imp": {
-    "unicode": "1F47F",
+    "unicode": "1f47f",
     "unicode_alternates": [],
     "name": "imp",
     "shortname": ":imp:",
@@ -211,7 +211,7 @@
     ]
   },
   "wink": {
-    "unicode": "1F609",
+    "unicode": "1f609",
     "unicode_alternates": [],
     "name": "winking face",
     "shortname": ":wink:",
@@ -238,7 +238,7 @@
     ]
   },
   "blush": {
-    "unicode": "1F60A",
+    "unicode": "1f60a",
     "unicode_alternates": [],
     "name": "smiling face with smiling eyes",
     "shortname": ":blush:",
@@ -257,7 +257,7 @@
     ]
   },
   "relaxed": {
-    "unicode": "263A",
+    "unicode": "263a",
     "unicode_alternates": [
       "263A-FE0F"
     ],
@@ -276,7 +276,7 @@
     ]
   },
   "yum": {
-    "unicode": "1F60B",
+    "unicode": "1f60b",
     "unicode_alternates": [],
     "name": "face savouring delicious food",
     "shortname": ":yum:",
@@ -297,7 +297,7 @@
     ]
   },
   "relieved": {
-    "unicode": "1F60C",
+    "unicode": "1f60c",
     "unicode_alternates": [],
     "name": "relieved face",
     "shortname": ":relieved:",
@@ -315,7 +315,7 @@
     ]
   },
   "heart_eyes": {
-    "unicode": "1F60D",
+    "unicode": "1f60d",
     "unicode_alternates": [],
     "name": "smiling face with heart-shaped eyes",
     "shortname": ":heart_eyes:",
@@ -337,7 +337,7 @@
     ]
   },
   "sunglasses": {
-    "unicode": "1F60E",
+    "unicode": "1f60e",
     "unicode_alternates": [],
     "name": "smiling face with sunglasses",
     "shortname": ":sunglasses:",
@@ -361,7 +361,7 @@
     ]
   },
   "smirk": {
-    "unicode": "1F60F",
+    "unicode": "1f60f",
     "unicode_alternates": [],
     "name": "smirking face",
     "shortname": ":smirk:",
@@ -380,7 +380,7 @@
     ]
   },
   "neutral_face": {
-    "unicode": "1F610",
+    "unicode": "1f610",
     "unicode_alternates": [],
     "name": "neutral face",
     "shortname": ":neutral_face:",
@@ -396,7 +396,7 @@
     ]
   },
   "expressionless": {
-    "unicode": "1F611",
+    "unicode": "1f611",
     "unicode_alternates": [],
     "name": "expressionless face",
     "shortname": ":expressionless:",
@@ -417,7 +417,7 @@
     ]
   },
   "unamused": {
-    "unicode": "1F612",
+    "unicode": "1f612",
     "unicode_alternates": [],
     "name": "unamused face",
     "shortname": ":unamused:",
@@ -438,7 +438,7 @@
     ]
   },
   "sweat": {
-    "unicode": "1F613",
+    "unicode": "1f613",
     "unicode_alternates": [],
     "name": "face with cold sweat",
     "shortname": ":sweat:",
@@ -460,7 +460,7 @@
     ]
   },
   "pensive": {
-    "unicode": "1F614",
+    "unicode": "1f614",
     "unicode_alternates": [],
     "name": "pensive face",
     "shortname": ":pensive:",
@@ -480,7 +480,7 @@
     ]
   },
   "confused": {
-    "unicode": "1F615",
+    "unicode": "1f615",
     "unicode_alternates": [],
     "name": "confused face",
     "shortname": ":confused:",
@@ -511,7 +511,7 @@
     ]
   },
   "confounded": {
-    "unicode": "1F616",
+    "unicode": "1f616",
     "unicode_alternates": [],
     "name": "confounded face",
     "shortname": ":confounded:",
@@ -530,7 +530,7 @@
     ]
   },
   "kissing": {
-    "unicode": "1F617",
+    "unicode": "1f617",
     "unicode_alternates": [],
     "name": "kissing face",
     "shortname": ":kissing:",
@@ -551,7 +551,7 @@
     ]
   },
   "kissing_heart": {
-    "unicode": "1F618",
+    "unicode": "1f618",
     "unicode_alternates": [],
     "name": "face throwing a kiss",
     "shortname": ":kissing_heart:",
@@ -576,7 +576,7 @@
     ]
   },
   "kissing_smiling_eyes": {
-    "unicode": "1F619",
+    "unicode": "1f619",
     "unicode_alternates": [],
     "name": "kissing face with smiling eyes",
     "shortname": ":kissing_smiling_eyes:",
@@ -596,7 +596,7 @@
     ]
   },
   "kissing_closed_eyes": {
-    "unicode": "1F61A",
+    "unicode": "1f61a",
     "unicode_alternates": [],
     "name": "kissing face with closed eyes",
     "shortname": ":kissing_closed_eyes:",
@@ -618,7 +618,7 @@
     ]
   },
   "stuck_out_tongue": {
-    "unicode": "1F61B",
+    "unicode": "1f61b",
     "unicode_alternates": [],
     "name": "face with stuck-out tongue",
     "shortname": ":stuck_out_tongue:",
@@ -651,7 +651,7 @@
     ]
   },
   "stuck_out_tongue_winking_eye": {
-    "unicode": "1F61C",
+    "unicode": "1f61c",
     "unicode_alternates": [],
     "name": "face with stuck-out tongue and winking eye",
     "shortname": ":stuck_out_tongue_winking_eye:",
@@ -676,7 +676,7 @@
     ]
   },
   "stuck_out_tongue_closed_eyes": {
-    "unicode": "1F61D",
+    "unicode": "1f61d",
     "unicode_alternates": [],
     "name": "face with stuck-out tongue and tightly-closed eyes",
     "shortname": ":stuck_out_tongue_closed_eyes:",
@@ -695,7 +695,7 @@
     ]
   },
   "disappointed": {
-    "unicode": "1F61E",
+    "unicode": "1f61e",
     "unicode_alternates": [],
     "name": "disappointed face",
     "shortname": ":disappointed:",
@@ -720,7 +720,7 @@
     ]
   },
   "worried": {
-    "unicode": "1F61F",
+    "unicode": "1f61f",
     "unicode_alternates": [],
     "name": "worried face",
     "shortname": ":worried:",
@@ -737,7 +737,7 @@
     ]
   },
   "angry": {
-    "unicode": "1F620",
+    "unicode": "1f620",
     "unicode_alternates": [],
     "name": "angry face",
     "shortname": ":angry:",
@@ -759,7 +759,7 @@
     ]
   },
   "rage": {
-    "unicode": "1F621",
+    "unicode": "1f621",
     "unicode_alternates": [],
     "name": "pouting face",
     "shortname": ":rage:",
@@ -779,7 +779,7 @@
     ]
   },
   "cry": {
-    "unicode": "1F622",
+    "unicode": "1f622",
     "unicode_alternates": [],
     "name": "crying face",
     "shortname": ":cry:",
@@ -800,7 +800,7 @@
     ]
   },
   "persevere": {
-    "unicode": "1F623",
+    "unicode": "1f623",
     "unicode_alternates": [],
     "name": "persevering face",
     "shortname": ":persevere:",
@@ -819,7 +819,7 @@
     ]
   },
   "triumph": {
-    "unicode": "1F624",
+    "unicode": "1f624",
     "unicode_alternates": [],
     "name": "face with look of triumph",
     "shortname": ":triumph:",
@@ -835,7 +835,7 @@
     ]
   },
   "disappointed_relieved": {
-    "unicode": "1F625",
+    "unicode": "1f625",
     "unicode_alternates": [],
     "name": "disappointed but relieved face",
     "shortname": ":disappointed_relieved:",
@@ -851,7 +851,7 @@
     ]
   },
   "frowning": {
-    "unicode": "1F626",
+    "unicode": "1f626",
     "unicode_alternates": [],
     "name": "frowning face with open mouth",
     "shortname": ":frowning:",
@@ -869,7 +869,7 @@
     ]
   },
   "anguished": {
-    "unicode": "1F627",
+    "unicode": "1f627",
     "unicode_alternates": [],
     "name": "anguished face",
     "shortname": ":anguished:",
@@ -889,7 +889,7 @@
     ]
   },
   "fearful": {
-    "unicode": "1F628",
+    "unicode": "1f628",
     "unicode_alternates": [],
     "name": "fearful face",
     "shortname": ":fearful:",
@@ -907,7 +907,7 @@
     ]
   },
   "weary": {
-    "unicode": "1F629",
+    "unicode": "1f629",
     "unicode_alternates": [],
     "name": "weary face",
     "shortname": ":weary:",
@@ -928,7 +928,7 @@
     ]
   },
   "sleepy": {
-    "unicode": "1F62A",
+    "unicode": "1f62a",
     "unicode_alternates": [],
     "name": "sleepy face",
     "shortname": ":sleepy:",
@@ -943,7 +943,7 @@
     ]
   },
   "tired_face": {
-    "unicode": "1F62B",
+    "unicode": "1f62b",
     "unicode_alternates": [],
     "name": "tired face",
     "shortname": ":tired_face:",
@@ -961,7 +961,7 @@
     ]
   },
   "grimacing": {
-    "unicode": "1F62C",
+    "unicode": "1f62c",
     "unicode_alternates": [],
     "name": "grimacing face",
     "shortname": ":grimacing:",
@@ -977,7 +977,7 @@
     ]
   },
   "sob": {
-    "unicode": "1F62D",
+    "unicode": "1f62d",
     "unicode_alternates": [],
     "name": "loudly crying face",
     "shortname": ":sob:",
@@ -998,7 +998,7 @@
     ]
   },
   "open_mouth": {
-    "unicode": "1F62E",
+    "unicode": "1f62e",
     "unicode_alternates": [],
     "name": "face with open mouth",
     "shortname": ":open_mouth:",
@@ -1022,7 +1022,7 @@
     ]
   },
   "hushed": {
-    "unicode": "1F62F",
+    "unicode": "1f62f",
     "unicode_alternates": [],
     "name": "hushed face",
     "shortname": ":hushed:",
@@ -1039,7 +1039,7 @@
     ]
   },
   "cold_sweat": {
-    "unicode": "1F630",
+    "unicode": "1f630",
     "unicode_alternates": [],
     "name": "face with open mouth and cold sweat",
     "shortname": ":cold_sweat:",
@@ -1054,7 +1054,7 @@
     ]
   },
   "scream": {
-    "unicode": "1F631",
+    "unicode": "1f631",
     "unicode_alternates": [],
     "name": "face screaming in fear",
     "shortname": ":scream:",
@@ -1071,7 +1071,7 @@
     ]
   },
   "astonished": {
-    "unicode": "1F632",
+    "unicode": "1f632",
     "unicode_alternates": [],
     "name": "astonished face",
     "shortname": ":astonished:",
@@ -1086,7 +1086,7 @@
     ]
   },
   "flushed": {
-    "unicode": "1F633",
+    "unicode": "1f633",
     "unicode_alternates": [],
     "name": "flushed face",
     "shortname": ":flushed:",
@@ -1109,7 +1109,7 @@
     ]
   },
   "sleeping": {
-    "unicode": "1F634",
+    "unicode": "1f634",
     "unicode_alternates": [],
     "name": "sleeping face",
     "shortname": ":sleeping:",
@@ -1126,7 +1126,7 @@
     ]
   },
   "dizzy_face": {
-    "unicode": "1F635",
+    "unicode": "1f635",
     "unicode_alternates": [],
     "name": "dizzy face",
     "shortname": ":dizzy_face:",
@@ -1151,7 +1151,7 @@
     ]
   },
   "no_mouth": {
-    "unicode": "1F636",
+    "unicode": "1f636",
     "unicode_alternates": [],
     "name": "face without mouth",
     "shortname": ":no_mouth:",
@@ -1176,7 +1176,7 @@
     ]
   },
   "mask": {
-    "unicode": "1F637",
+    "unicode": "1f637",
     "unicode_alternates": [],
     "name": "face with medical mask",
     "shortname": ":mask:",
@@ -1192,7 +1192,7 @@
     ]
   },
   "slight_frown": {
-    "unicode": "1F641",
+    "unicode": "1f641",
     "unicode_alternates": [],
     "name": "slightly frowning face",
     "shortname": ":slight_frown:",
@@ -1210,7 +1210,7 @@
     ]
   },
   "slight_smile": {
-    "unicode": "1F642",
+    "unicode": "1f642",
     "unicode_alternates": [],
     "name": "slightly smiling face",
     "shortname": ":slight_smile:",
@@ -1227,7 +1227,7 @@
     ]
   },
   "smile_cat": {
-    "unicode": "1F638",
+    "unicode": "1f638",
     "unicode_alternates": [],
     "name": "grinning cat face with smiling eyes",
     "shortname": ":smile_cat:",
@@ -1243,7 +1243,7 @@
     ]
   },
   "joy_cat": {
-    "unicode": "1F639",
+    "unicode": "1f639",
     "unicode_alternates": [],
     "name": "cat face with tears of joy",
     "shortname": ":joy_cat:",
@@ -1264,7 +1264,7 @@
     ]
   },
   "smiley_cat": {
-    "unicode": "1F63A",
+    "unicode": "1f63a",
     "unicode_alternates": [],
     "name": "smiling cat face with open mouth",
     "shortname": ":smiley_cat:",
@@ -1281,7 +1281,7 @@
     ]
   },
   "heart_eyes_cat": {
-    "unicode": "1F63B",
+    "unicode": "1f63b",
     "unicode_alternates": [],
     "name": "smiling cat face with heart-shaped eyes",
     "shortname": ":heart_eyes_cat:",
@@ -1302,7 +1302,7 @@
     ]
   },
   "smirk_cat": {
-    "unicode": "1F63C",
+    "unicode": "1f63c",
     "unicode_alternates": [],
     "name": "cat face with wry smile",
     "shortname": ":smirk_cat:",
@@ -1320,7 +1320,7 @@
     ]
   },
   "kissing_cat": {
-    "unicode": "1F63D",
+    "unicode": "1f63d",
     "unicode_alternates": [],
     "name": "kissing cat face with closed eyes",
     "shortname": ":kissing_cat:",
@@ -1339,7 +1339,7 @@
     ]
   },
   "pouting_cat": {
-    "unicode": "1F63E",
+    "unicode": "1f63e",
     "unicode_alternates": [],
     "name": "pouting cat face",
     "shortname": ":pouting_cat:",
@@ -1358,7 +1358,7 @@
     ]
   },
   "crying_cat_face": {
-    "unicode": "1F63F",
+    "unicode": "1f63f",
     "unicode_alternates": [],
     "name": "crying cat face",
     "shortname": ":crying_cat_face:",
@@ -1383,7 +1383,7 @@
     ]
   },
   "scream_cat": {
-    "unicode": "1F640",
+    "unicode": "1f640",
     "unicode_alternates": [],
     "name": "weary cat face",
     "shortname": ":scream_cat:",
@@ -1408,7 +1408,7 @@
     ]
   },
   "footprints": {
-    "unicode": "1F463",
+    "unicode": "1f463",
     "unicode_alternates": [],
     "name": "footprints",
     "shortname": ":footprints:",
@@ -1421,7 +1421,7 @@
     ]
   },
   "bust_in_silhouette": {
-    "unicode": "1F464",
+    "unicode": "1f464",
     "unicode_alternates": [],
     "name": "bust in silhouette",
     "shortname": ":bust_in_silhouette:",
@@ -1446,7 +1446,7 @@
     ]
   },
   "busts_in_silhouette": {
-    "unicode": "1F465",
+    "unicode": "1f465",
     "unicode_alternates": [],
     "name": "busts in silhouette",
     "shortname": ":busts_in_silhouette:",
@@ -1469,7 +1469,7 @@
     ]
   },
   "levitate": {
-    "unicode": "1F574",
+    "unicode": "1f574",
     "unicode_alternates": [],
     "name": "man in business suit levitating",
     "shortname": ":levitate:",
@@ -1485,7 +1485,7 @@
     ]
   },
   "spy": {
-    "unicode": "1F575",
+    "unicode": "1f575",
     "unicode_alternates": [],
     "name": "sleuth or spy",
     "shortname": ":spy:",
@@ -1502,7 +1502,7 @@
     ]
   },
   "baby": {
-    "unicode": "1F476",
+    "unicode": "1f476",
     "unicode_alternates": [],
     "name": "baby",
     "shortname": ":baby:",
@@ -1517,7 +1517,7 @@
     ]
   },
   "boy": {
-    "unicode": "1F466",
+    "unicode": "1f466",
     "unicode_alternates": [],
     "name": "boy",
     "shortname": ":boy:",
@@ -1532,7 +1532,7 @@
     ]
   },
   "girl": {
-    "unicode": "1F467",
+    "unicode": "1f467",
     "unicode_alternates": [],
     "name": "girl",
     "shortname": ":girl:",
@@ -1547,7 +1547,7 @@
     ]
   },
   "man": {
-    "unicode": "1F468",
+    "unicode": "1f468",
     "unicode_alternates": [],
     "name": "man",
     "shortname": ":man:",
@@ -1564,7 +1564,7 @@
     ]
   },
   "woman": {
-    "unicode": "1F469",
+    "unicode": "1f469",
     "unicode_alternates": [],
     "name": "woman",
     "shortname": ":woman:",
@@ -1579,7 +1579,7 @@
     ]
   },
   "family": {
-    "unicode": "1F46A",
+    "unicode": "1f46a",
     "unicode_alternates": [],
     "name": "family",
     "shortname": ":family:",
@@ -1603,7 +1603,7 @@
     ]
   },
   "family_mwg": {
-    "unicode": "1F468-1F469-1F467",
+    "unicode": "1f468-1F469-1F467",
     "unicode_alternates": [
       "1F468-200D-1F469-200D-1F467"
     ],
@@ -1629,7 +1629,7 @@
     ]
   },
   "family_mwgb": {
-    "unicode": "1F468-1F469-1F467-1F466",
+    "unicode": "1f468-1F469-1F467-1F466",
     "unicode_alternates": [
       "1F468-200D-1F469-200D-1F467-200D-1F466"
     ],
@@ -1655,7 +1655,7 @@
     ]
   },
   "family_mwbb": {
-    "unicode": "1F468-1F469-1F466-1F466",
+    "unicode": "1f468-1F469-1F466-1F466",
     "unicode_alternates": [
       "1F468-200D-1F469-200D-1F466-200D-1F466"
     ],
@@ -1680,7 +1680,7 @@
     ]
   },
   "family_mwgg": {
-    "unicode": "1F468-1F469-1F467-1F467",
+    "unicode": "1f468-1F469-1F467-1F467",
     "unicode_alternates": [
       "1F468-200D-1F469-200D-1F467-200D-1F467"
     ],
@@ -1705,7 +1705,7 @@
     ]
   },
   "family_wwb": {
-    "unicode": "1F469-1F469-1F466",
+    "unicode": "1f469-1F469-1F466",
     "unicode_alternates": [
       "1F469-200D-1F469-200D-1F466"
     ],
@@ -1730,7 +1730,7 @@
     ]
   },
   "family_wwg": {
-    "unicode": "1F469-1F469-1F467",
+    "unicode": "1f469-1F469-1F467",
     "unicode_alternates": [
       "1F469-200D-1F469-200D-1F467"
     ],
@@ -1755,7 +1755,7 @@
     ]
   },
   "family_wwgb": {
-    "unicode": "1F469-1F469-1F467-1F466",
+    "unicode": "1f469-1F469-1F467-1F466",
     "unicode_alternates": [
       "1F469-200D-1F469-200D-1F467-200D-1F466"
     ],
@@ -1781,7 +1781,7 @@
     ]
   },
   "family_wwbb": {
-    "unicode": "1F469-1F469-1F466-1F466",
+    "unicode": "1f469-1F469-1F466-1F466",
     "unicode_alternates": [
       "1F469-200D-1F469-200D-1F466-200D-1F466"
     ],
@@ -1806,7 +1806,7 @@
     ]
   },
   "family_wwgg": {
-    "unicode": "1F469-1F469-1F467-1F467",
+    "unicode": "1f469-1F469-1F467-1F467",
     "unicode_alternates": [
       "1F469-200D-1F469-200D-1F467-200D-1F467"
     ],
@@ -1831,7 +1831,7 @@
     ]
   },
   "family_mmb": {
-    "unicode": "1F468-1F468-1F466",
+    "unicode": "1f468-1F468-1F466",
     "unicode_alternates": [
       "1F468-200D-1F468-200D-1F466"
     ],
@@ -1855,7 +1855,7 @@
     ]
   },
   "family_mmg": {
-    "unicode": "1F468-1F468-1F467",
+    "unicode": "1f468-1F468-1F467",
     "unicode_alternates": [
       "1F468-200D-1F468-200D-1F467"
     ],
@@ -1879,7 +1879,7 @@
     ]
   },
   "family_mmgb": {
-    "unicode": "1F468-1F468-1F467-1F466",
+    "unicode": "1f468-1F468-1F467-1F466",
     "unicode_alternates": [
       "1F468-200D-1F468-200D-1F467-200D-1F466"
     ],
@@ -1904,7 +1904,7 @@
     ]
   },
   "family_mmbb": {
-    "unicode": "1F468-1F468-1F466-1F466",
+    "unicode": "1f468-1F468-1F466-1F466",
     "unicode_alternates": [
       "1F468-200D-1F468-200D-1F466-200D-1F466"
     ],
@@ -1928,7 +1928,7 @@
     ]
   },
   "family_mmgg": {
-    "unicode": "1F468-1F468-1F467-1F467",
+    "unicode": "1f468-1F468-1F467-1F467",
     "unicode_alternates": [
       "1F468-200D-1F468-200D-1F467-200D-1F467"
     ],
@@ -1952,7 +1952,7 @@
     ]
   },
   "couple": {
-    "unicode": "1F46B",
+    "unicode": "1f46b",
     "unicode_alternates": [],
     "name": "man and woman holding hands",
     "shortname": ":couple:",
@@ -1973,7 +1973,7 @@
     ]
   },
   "two_men_holding_hands": {
-    "unicode": "1F46C",
+    "unicode": "1f46c",
     "unicode_alternates": [],
     "name": "two men holding hands",
     "shortname": ":two_men_holding_hands:",
@@ -1995,7 +1995,7 @@
     ]
   },
   "two_women_holding_hands": {
-    "unicode": "1F46D",
+    "unicode": "1f46d",
     "unicode_alternates": [],
     "name": "two women holding hands",
     "shortname": ":two_women_holding_hands:",
@@ -2021,7 +2021,7 @@
     ]
   },
   "dancers": {
-    "unicode": "1F46F",
+    "unicode": "1f46f",
     "unicode_alternates": [],
     "name": "woman with bunny ears",
     "shortname": ":dancers:",
@@ -2042,7 +2042,7 @@
     ]
   },
   "bride_with_veil": {
-    "unicode": "1F470",
+    "unicode": "1f470",
     "unicode_alternates": [],
     "name": "bride with veil",
     "shortname": ":bride_with_veil:",
@@ -2063,7 +2063,7 @@
     ]
   },
   "person_with_blond_hair": {
-    "unicode": "1F471",
+    "unicode": "1f471",
     "unicode_alternates": [],
     "name": "person with blond hair",
     "shortname": ":person_with_blond_hair:",
@@ -2082,7 +2082,7 @@
     ]
   },
   "man_with_gua_pi_mao": {
-    "unicode": "1F472",
+    "unicode": "1f472",
     "unicode_alternates": [],
     "name": "man with gua pi mao",
     "shortname": ":man_with_gua_pi_mao:",
@@ -2100,7 +2100,7 @@
     ]
   },
   "man_with_turban": {
-    "unicode": "1F473",
+    "unicode": "1f473",
     "unicode_alternates": [],
     "name": "man with turban",
     "shortname": ":man_with_turban:",
@@ -2121,7 +2121,7 @@
     ]
   },
   "older_man": {
-    "unicode": "1F474",
+    "unicode": "1f474",
     "unicode_alternates": [],
     "name": "older man",
     "shortname": ":older_man:",
@@ -2135,7 +2135,7 @@
     ]
   },
   "older_woman": {
-    "unicode": "1F475",
+    "unicode": "1f475",
     "unicode_alternates": [],
     "name": "older woman",
     "shortname": ":older_woman:",
@@ -2154,7 +2154,7 @@
     ]
   },
   "cop": {
-    "unicode": "1F46E",
+    "unicode": "1f46e",
     "unicode_alternates": [],
     "name": "police officer",
     "shortname": ":cop:",
@@ -2171,7 +2171,7 @@
     ]
   },
   "construction_worker": {
-    "unicode": "1F477",
+    "unicode": "1f477",
     "unicode_alternates": [],
     "name": "construction worker",
     "shortname": ":construction_worker:",
@@ -2187,7 +2187,7 @@
     ]
   },
   "princess": {
-    "unicode": "1F478",
+    "unicode": "1f478",
     "unicode_alternates": [],
     "name": "princess",
     "shortname": ":princess:",
@@ -2211,7 +2211,7 @@
     ]
   },
   "guardsman": {
-    "unicode": "1F482",
+    "unicode": "1f482",
     "unicode_alternates": [],
     "name": "guardsman",
     "shortname": ":guardsman:",
@@ -2235,7 +2235,7 @@
     ]
   },
   "angel": {
-    "unicode": "1F47C",
+    "unicode": "1f47c",
     "unicode_alternates": [],
     "name": "baby angel",
     "shortname": ":angel:",
@@ -2252,7 +2252,7 @@
     ]
   },
   "santa": {
-    "unicode": "1F385",
+    "unicode": "1f385",
     "unicode_alternates": [],
     "name": "father christmas",
     "shortname": ":santa:",
@@ -2279,7 +2279,7 @@
     ]
   },
   "ghost": {
-    "unicode": "1F47B",
+    "unicode": "1f47b",
     "unicode_alternates": [],
     "name": "ghost",
     "shortname": ":ghost:",
@@ -2292,7 +2292,7 @@
     ]
   },
   "japanese_ogre": {
-    "unicode": "1F479",
+    "unicode": "1f479",
     "unicode_alternates": [],
     "name": "japanese ogre",
     "shortname": ":japanese_ogre:",
@@ -2315,7 +2315,7 @@
     ]
   },
   "japanese_goblin": {
-    "unicode": "1F47A",
+    "unicode": "1f47a",
     "unicode_alternates": [],
     "name": "japanese goblin",
     "shortname": ":japanese_goblin:",
@@ -2341,7 +2341,7 @@
     ]
   },
   "poop": {
-    "unicode": "1F4A9",
+    "unicode": "1f4a9",
     "unicode_alternates": [],
     "name": "pile of poo",
     "shortname": ":poop:",
@@ -2361,7 +2361,7 @@
     ]
   },
   "skull": {
-    "unicode": "1F480",
+    "unicode": "1f480",
     "unicode_alternates": [],
     "name": "skull",
     "shortname": ":skull:",
@@ -2379,7 +2379,7 @@
     ]
   },
   "alien": {
-    "unicode": "1F47D",
+    "unicode": "1f47d",
     "unicode_alternates": [],
     "name": "extraterrestrial alien",
     "shortname": ":alien:",
@@ -2394,7 +2394,7 @@
     ]
   },
   "space_invader": {
-    "unicode": "1F47E",
+    "unicode": "1f47e",
     "unicode_alternates": [],
     "name": "alien monster",
     "shortname": ":space_invader:",
@@ -2410,7 +2410,7 @@
     ]
   },
   "bow": {
-    "unicode": "1F647",
+    "unicode": "1f647",
     "unicode_alternates": [],
     "name": "person bowing deeply",
     "shortname": ":bow:",
@@ -2429,7 +2429,7 @@
     ]
   },
   "information_desk_person": {
-    "unicode": "1F481",
+    "unicode": "1f481",
     "unicode_alternates": [],
     "name": "information desk person",
     "shortname": ":information_desk_person:",
@@ -2452,7 +2452,7 @@
     ]
   },
   "no_good": {
-    "unicode": "1F645",
+    "unicode": "1f645",
     "unicode_alternates": [],
     "name": "face with no good gesture",
     "shortname": ":no_good:",
@@ -2471,7 +2471,7 @@
     ]
   },
   "ok_woman": {
-    "unicode": "1F646",
+    "unicode": "1f646",
     "unicode_alternates": [],
     "name": "face with ok gesture",
     "shortname": ":ok_woman:",
@@ -2496,7 +2496,7 @@
     ]
   },
   "raising_hand": {
-    "unicode": "1F64B",
+    "unicode": "1f64b",
     "unicode_alternates": [],
     "name": "happy person raising one hand",
     "shortname": ":raising_hand:",
@@ -2515,7 +2515,7 @@
     ]
   },
   "person_with_pouting_face": {
-    "unicode": "1F64E",
+    "unicode": "1f64e",
     "unicode_alternates": [],
     "name": "person with pouting face",
     "shortname": ":person_with_pouting_face:",
@@ -2534,7 +2534,7 @@
     ]
   },
   "person_frowning": {
-    "unicode": "1F64D",
+    "unicode": "1f64d",
     "unicode_alternates": [],
     "name": "person frowning",
     "shortname": ":person_frowning:",
@@ -2553,7 +2553,7 @@
     ]
   },
   "massage": {
-    "unicode": "1F486",
+    "unicode": "1f486",
     "unicode_alternates": [],
     "name": "face massage",
     "shortname": ":massage:",
@@ -2568,7 +2568,7 @@
     ]
   },
   "haircut": {
-    "unicode": "1F487",
+    "unicode": "1f487",
     "unicode_alternates": [],
     "name": "haircut",
     "shortname": ":haircut:",
@@ -2583,7 +2583,7 @@
     ]
   },
   "couple_with_heart": {
-    "unicode": "1F491",
+    "unicode": "1f491",
     "unicode_alternates": [],
     "name": "couple with heart",
     "shortname": ":couple_with_heart:",
@@ -2602,7 +2602,7 @@
     ]
   },
   "couple_ww": {
-    "unicode": "1F469-2764-1F469",
+    "unicode": "1f469-2764-1F469",
     "unicode_alternates": [
       "1F469-200D-2764-FE0F-200D-1F469"
     ],
@@ -2625,7 +2625,7 @@
     ]
   },
   "couple_mm": {
-    "unicode": "1F468-2764-1F468",
+    "unicode": "1f468-2764-1F468",
     "unicode_alternates": [
       "1F468-200D-2764-FE0F-200D-1F468"
     ],
@@ -2648,7 +2648,7 @@
     ]
   },
   "couplekiss": {
-    "unicode": "1F48F",
+    "unicode": "1f48f",
     "unicode_alternates": [],
     "name": "kiss",
     "shortname": ":couplekiss:",
@@ -2666,7 +2666,7 @@
     ]
   },
   "kiss_ww": {
-    "unicode": "1F469-2764-1F48B-1F469",
+    "unicode": "1f469-2764-1F48B-1F469",
     "unicode_alternates": [
       "1F469-200D-2764-FE0F-200D-1F48B-200D-1F469"
     ],
@@ -2688,7 +2688,7 @@
     ]
   },
   "kiss_mm": {
-    "unicode": "1F468-2764-1F48B-1F468",
+    "unicode": "1f468-2764-1F48B-1F468",
     "unicode_alternates": [
       "1F468-200D-2764-FE0F-200D-1F48B-200D-1F468"
     ],
@@ -2710,7 +2710,7 @@
     ]
   },
   "raised_hands": {
-    "unicode": "1F64C",
+    "unicode": "1f64c",
     "unicode_alternates": [],
     "name": "person raising both hands in celebration",
     "shortname": ":raised_hands:",
@@ -2729,7 +2729,7 @@
     ]
   },
   "clap": {
-    "unicode": "1F44F",
+    "unicode": "1f44f",
     "unicode_alternates": [],
     "name": "clapping hands sign",
     "shortname": ":clap:",
@@ -2750,7 +2750,7 @@
     ]
   },
   "ear": {
-    "unicode": "1F442",
+    "unicode": "1f442",
     "unicode_alternates": [],
     "name": "ear",
     "shortname": ":ear:",
@@ -2765,7 +2765,7 @@
     ]
   },
   "eye": {
-    "unicode": "1F441",
+    "unicode": "1f441",
     "unicode_alternates": [],
     "name": "eye",
     "shortname": ":eye:",
@@ -2780,7 +2780,7 @@
     ]
   },
   "eyes": {
-    "unicode": "1F440",
+    "unicode": "1f440",
     "unicode_alternates": [],
     "name": "eyes",
     "shortname": ":eyes:",
@@ -2796,7 +2796,7 @@
     ]
   },
   "nose": {
-    "unicode": "1F443",
+    "unicode": "1f443",
     "unicode_alternates": [],
     "name": "nose",
     "shortname": ":nose:",
@@ -2810,7 +2810,7 @@
     ]
   },
   "lips": {
-    "unicode": "1F444",
+    "unicode": "1f444",
     "unicode_alternates": [],
     "name": "mouth",
     "shortname": ":lips:",
@@ -2825,7 +2825,7 @@
     ]
   },
   "lips2": {
-    "unicode": "1F5E2",
+    "unicode": "1f5e2",
     "unicode_alternates": [],
     "name": "lips",
     "shortname": ":lips2:",
@@ -2839,7 +2839,7 @@
     ]
   },
   "kiss": {
-    "unicode": "1F48B",
+    "unicode": "1f48b",
     "unicode_alternates": [],
     "name": "kiss mark",
     "shortname": ":kiss:",
@@ -2857,7 +2857,7 @@
     ]
   },
   "tongue": {
-    "unicode": "1F445",
+    "unicode": "1f445",
     "unicode_alternates": [],
     "name": "tongue",
     "shortname": ":tongue:",
@@ -2884,7 +2884,7 @@
     ]
   },
   "nail_care": {
-    "unicode": "1F485",
+    "unicode": "1f485",
     "unicode_alternates": [],
     "name": "nail polish",
     "shortname": ":nail_care:",
@@ -2898,7 +2898,7 @@
     ]
   },
   "wave": {
-    "unicode": "1F44B",
+    "unicode": "1f44b",
     "unicode_alternates": [],
     "name": "waving hand sign",
     "shortname": ":wave:",
@@ -2916,7 +2916,7 @@
     ]
   },
   "thumbsup": {
-    "unicode": "1F44D",
+    "unicode": "1f44d",
     "unicode_alternates": [],
     "name": "thumbs up sign",
     "shortname": ":thumbsup:",
@@ -2935,7 +2935,7 @@
     ]
   },
   "thumbsdown": {
-    "unicode": "1F44E",
+    "unicode": "1f44e",
     "unicode_alternates": [],
     "name": "thumbs down sign",
     "shortname": ":thumbsdown:",
@@ -2952,7 +2952,7 @@
     ]
   },
   "point_up": {
-    "unicode": "261D",
+    "unicode": "261d",
     "unicode_alternates": [
       "261D-FE0F"
     ],
@@ -2970,7 +2970,7 @@
     ]
   },
   "point_up_2": {
-    "unicode": "1F446",
+    "unicode": "1f446",
     "unicode_alternates": [],
     "name": "white up pointing backhand index",
     "shortname": ":point_up_2:",
@@ -2986,7 +2986,7 @@
     ]
   },
   "point_down": {
-    "unicode": "1F447",
+    "unicode": "1f447",
     "unicode_alternates": [],
     "name": "white down pointing backhand index",
     "shortname": ":point_down:",
@@ -3001,7 +3001,7 @@
     ]
   },
   "point_left": {
-    "unicode": "1F448",
+    "unicode": "1f448",
     "unicode_alternates": [],
     "name": "white left pointing backhand index",
     "shortname": ":point_left:",
@@ -3016,7 +3016,7 @@
     ]
   },
   "point_right": {
-    "unicode": "1F449",
+    "unicode": "1f449",
     "unicode_alternates": [],
     "name": "white right pointing backhand index",
     "shortname": ":point_right:",
@@ -3031,7 +3031,7 @@
     ]
   },
   "ok_hand": {
-    "unicode": "1F44C",
+    "unicode": "1f44c",
     "unicode_alternates": [],
     "name": "ok hand sign",
     "shortname": ":ok_hand:",
@@ -3053,7 +3053,7 @@
     ]
   },
   "v": {
-    "unicode": "270C",
+    "unicode": "270c",
     "unicode_alternates": [
       "270C-FE0F"
     ],
@@ -3072,7 +3072,7 @@
     ]
   },
   "punch": {
-    "unicode": "1F44A",
+    "unicode": "1f44a",
     "unicode_alternates": [],
     "name": "fisted hand sign",
     "shortname": ":punch:",
@@ -3086,7 +3086,7 @@
     ]
   },
   "fist": {
-    "unicode": "270A",
+    "unicode": "270a",
     "unicode_alternates": [],
     "name": "raised fist",
     "shortname": ":fist:",
@@ -3101,7 +3101,7 @@
     ]
   },
   "raised_hand": {
-    "unicode": "270B",
+    "unicode": "270b",
     "unicode_alternates": [],
     "name": "raised hand",
     "shortname": ":raised_hand:",
@@ -3116,7 +3116,7 @@
     ]
   },
   "muscle": {
-    "unicode": "1F4AA",
+    "unicode": "1f4aa",
     "unicode_alternates": [],
     "name": "flexed biceps",
     "shortname": ":muscle:",
@@ -3134,7 +3134,7 @@
     ]
   },
   "open_hands": {
-    "unicode": "1F450",
+    "unicode": "1f450",
     "unicode_alternates": [],
     "name": "open hands sign",
     "shortname": ":open_hands:",
@@ -3148,7 +3148,7 @@
     ]
   },
   "writing_hand": {
-    "unicode": "1F58E",
+    "unicode": "1f58e",
     "unicode_alternates": [],
     "name": "left writing hand",
     "shortname": ":writing_hand:",
@@ -3166,7 +3166,7 @@
     ]
   },
   "turned_ok_hand": {
-    "unicode": "1F58F",
+    "unicode": "1f58f",
     "unicode_alternates": [],
     "name": "turned ok hand sign",
     "shortname": ":turned_ok_hand:",
@@ -3182,7 +3182,7 @@
     ]
   },
   "hand_splayed": {
-    "unicode": "1F590",
+    "unicode": "1f590",
     "unicode_alternates": [],
     "name": "raised hand with fingers splayed",
     "shortname": ":hand_splayed:",
@@ -3200,7 +3200,7 @@
     ]
   },
   "hand_splayed_reverse": {
-    "unicode": "1F591",
+    "unicode": "1f591",
     "unicode_alternates": [],
     "name": "reversed raised hand with fingers splayed",
     "shortname": ":hand_splayed_reverse:",
@@ -3218,7 +3218,7 @@
     ]
   },
   "thumbs_up_reverse": {
-    "unicode": "1F592",
+    "unicode": "1f592",
     "unicode_alternates": [],
     "name": "reversed thumbs up sign",
     "shortname": ":thumbs_up_reverse:",
@@ -3237,7 +3237,7 @@
     ]
   },
   "thumbs_down_reverse": {
-    "unicode": "1F593",
+    "unicode": "1f593",
     "unicode_alternates": [],
     "name": "reversed thumbs down sign",
     "shortname": ":thumbs_down_reverse:",
@@ -3254,7 +3254,7 @@
     ]
   },
   "hand_victory": {
-    "unicode": "1F594",
+    "unicode": "1f594",
     "unicode_alternates": [],
     "name": "reversed victory hand",
     "shortname": ":hand_victory:",
@@ -3269,7 +3269,7 @@
     ]
   },
   "middle_finger": {
-    "unicode": "1F595",
+    "unicode": "1f595",
     "unicode_alternates": [],
     "name": "reversed hand with middle finger extended",
     "shortname": ":middle_finger:",
@@ -3284,7 +3284,7 @@
     ]
   },
   "vulcan": {
-    "unicode": "1F596",
+    "unicode": "1f596",
     "unicode_alternates": [],
     "name": "raised hand with part between middle and ring fingers",
     "shortname": ":vulcan:",
@@ -3304,7 +3304,7 @@
     ]
   },
   "finger_pointing_down": {
-    "unicode": "1F597",
+    "unicode": "1f597",
     "unicode_alternates": [],
     "name": "white down pointing left hand index",
     "shortname": ":finger_pointing_down:",
@@ -3321,7 +3321,7 @@
     ]
   },
   "finger_pointing_left": {
-    "unicode": "1F598",
+    "unicode": "1f598",
     "unicode_alternates": [],
     "name": "sideways white left pointing index",
     "shortname": ":finger_pointing_left:",
@@ -3338,7 +3338,7 @@
     ]
   },
   "finger_pointing_right": {
-    "unicode": "1F599",
+    "unicode": "1f599",
     "unicode_alternates": [],
     "name": "sideways white right pointing index",
     "shortname": ":finger_pointing_right:",
@@ -3355,7 +3355,7 @@
     ]
   },
   "finger_pointing_up": {
-    "unicode": "1F59E",
+    "unicode": "1f59e",
     "unicode_alternates": [],
     "name": "sideways white up pointing index",
     "shortname": ":finger_pointing_up:",
@@ -3372,7 +3372,7 @@
     ]
   },
   "finger_pointing_down2": {
-    "unicode": "1F59F",
+    "unicode": "1f59f",
     "unicode_alternates": [],
     "name": "sideways white down pointing index",
     "shortname": ":finger_pointing_down2:",
@@ -3389,7 +3389,7 @@
     ]
   },
   "pray": {
-    "unicode": "1F64F",
+    "unicode": "1f64f",
     "unicode_alternates": [],
     "name": "person with folded hands",
     "shortname": ":pray:",
@@ -3411,7 +3411,7 @@
     ]
   },
   "seedling": {
-    "unicode": "1F331",
+    "unicode": "1f331",
     "unicode_alternates": [],
     "name": "seedling",
     "shortname": ":seedling:",
@@ -3430,7 +3430,7 @@
     ]
   },
   "evergreen_tree": {
-    "unicode": "1F332",
+    "unicode": "1f332",
     "unicode_alternates": [],
     "name": "evergreen tree",
     "shortname": ":evergreen_tree:",
@@ -3446,7 +3446,7 @@
     ]
   },
   "deciduous_tree": {
-    "unicode": "1F333",
+    "unicode": "1f333",
     "unicode_alternates": [],
     "name": "deciduous tree",
     "shortname": ":deciduous_tree:",
@@ -3463,7 +3463,7 @@
     ]
   },
   "palm_tree": {
-    "unicode": "1F334",
+    "unicode": "1f334",
     "unicode_alternates": [],
     "name": "palm tree",
     "shortname": ":palm_tree:",
@@ -3481,7 +3481,7 @@
     ]
   },
   "cactus": {
-    "unicode": "1F335",
+    "unicode": "1f335",
     "unicode_alternates": [],
     "name": "cactus",
     "shortname": ":cactus:",
@@ -3500,7 +3500,7 @@
     ]
   },
   "tulip": {
-    "unicode": "1F337",
+    "unicode": "1f337",
     "unicode_alternates": [],
     "name": "tulip",
     "shortname": ":tulip:",
@@ -3518,7 +3518,7 @@
     ]
   },
   "cherry_blossom": {
-    "unicode": "1F338",
+    "unicode": "1f338",
     "unicode_alternates": [],
     "name": "cherry blossom",
     "shortname": ":cherry_blossom:",
@@ -3534,7 +3534,7 @@
     ]
   },
   "rose": {
-    "unicode": "1F339",
+    "unicode": "1f339",
     "unicode_alternates": [],
     "name": "rose",
     "shortname": ":rose:",
@@ -3553,7 +3553,7 @@
     ]
   },
   "hibiscus": {
-    "unicode": "1F33A",
+    "unicode": "1f33a",
     "unicode_alternates": [],
     "name": "hibiscus",
     "shortname": ":hibiscus:",
@@ -3569,7 +3569,7 @@
     ]
   },
   "sunflower": {
-    "unicode": "1F33B",
+    "unicode": "1f33b",
     "unicode_alternates": [],
     "name": "sunflower",
     "shortname": ":sunflower:",
@@ -3587,7 +3587,7 @@
     ]
   },
   "blossom": {
-    "unicode": "1F33C",
+    "unicode": "1f33c",
     "unicode_alternates": [],
     "name": "blossom",
     "shortname": ":blossom:",
@@ -3603,7 +3603,7 @@
     ]
   },
   "bouquet": {
-    "unicode": "1F490",
+    "unicode": "1f490",
     "unicode_alternates": [],
     "name": "bouquet",
     "shortname": ":bouquet:",
@@ -3617,7 +3617,7 @@
     ]
   },
   "ear_of_rice": {
-    "unicode": "1F33E",
+    "unicode": "1f33e",
     "unicode_alternates": [],
     "name": "ear of rice",
     "shortname": ":ear_of_rice:",
@@ -3633,7 +3633,7 @@
     ]
   },
   "herb": {
-    "unicode": "1F33F",
+    "unicode": "1f33f",
     "unicode_alternates": [],
     "name": "herb",
     "shortname": ":herb:",
@@ -3655,7 +3655,7 @@
     ]
   },
   "four_leaf_clover": {
-    "unicode": "1F340",
+    "unicode": "1f340",
     "unicode_alternates": [],
     "name": "four leaf clover",
     "shortname": ":four_leaf_clover:",
@@ -3675,7 +3675,7 @@
     ]
   },
   "maple_leaf": {
-    "unicode": "1F341",
+    "unicode": "1f341",
     "unicode_alternates": [],
     "name": "maple leaf",
     "shortname": ":maple_leaf:",
@@ -3692,7 +3692,7 @@
     ]
   },
   "fallen_leaf": {
-    "unicode": "1F342",
+    "unicode": "1f342",
     "unicode_alternates": [],
     "name": "fallen leaf",
     "shortname": ":fallen_leaf:",
@@ -3712,7 +3712,7 @@
     ]
   },
   "leaves": {
-    "unicode": "1F343",
+    "unicode": "1f343",
     "unicode_alternates": [],
     "name": "leaf fluttering in wind",
     "shortname": ":leaves:",
@@ -3731,7 +3731,7 @@
     ]
   },
   "mushroom": {
-    "unicode": "1F344",
+    "unicode": "1f344",
     "unicode_alternates": [],
     "name": "mushroom",
     "shortname": ":mushroom:",
@@ -3749,7 +3749,7 @@
     ]
   },
   "chestnut": {
-    "unicode": "1F330",
+    "unicode": "1f330",
     "unicode_alternates": [],
     "name": "chestnut",
     "shortname": ":chestnut:",
@@ -3766,7 +3766,7 @@
     ]
   },
   "rat": {
-    "unicode": "1F400",
+    "unicode": "1f400",
     "unicode_alternates": [],
     "name": "rat",
     "shortname": ":rat:",
@@ -3783,7 +3783,7 @@
     ]
   },
   "mouse2": {
-    "unicode": "1F401",
+    "unicode": "1f401",
     "unicode_alternates": [],
     "name": "mouse",
     "shortname": ":mouse2:",
@@ -3799,7 +3799,7 @@
     ]
   },
   "mouse": {
-    "unicode": "1F42D",
+    "unicode": "1f42d",
     "unicode_alternates": [],
     "name": "mouse face",
     "shortname": ":mouse:",
@@ -3814,7 +3814,7 @@
     ]
   },
   "hamster": {
-    "unicode": "1F439",
+    "unicode": "1f439",
     "unicode_alternates": [],
     "name": "hamster face",
     "shortname": ":hamster:",
@@ -3829,7 +3829,7 @@
     ]
   },
   "ox": {
-    "unicode": "1F402",
+    "unicode": "1f402",
     "unicode_alternates": [],
     "name": "ox",
     "shortname": ":ox:",
@@ -3845,7 +3845,7 @@
     ]
   },
   "water_buffalo": {
-    "unicode": "1F403",
+    "unicode": "1f403",
     "unicode_alternates": [],
     "name": "water buffalo",
     "shortname": ":water_buffalo:",
@@ -3863,7 +3863,7 @@
     ]
   },
   "cow2": {
-    "unicode": "1F404",
+    "unicode": "1f404",
     "unicode_alternates": [],
     "name": "cow",
     "shortname": ":cow2:",
@@ -3884,7 +3884,7 @@
     ]
   },
   "cow": {
-    "unicode": "1F42E",
+    "unicode": "1f42e",
     "unicode_alternates": [],
     "name": "cow face",
     "shortname": ":cow:",
@@ -3901,7 +3901,7 @@
     ]
   },
   "tiger2": {
-    "unicode": "1F405",
+    "unicode": "1f405",
     "unicode_alternates": [],
     "name": "tiger",
     "shortname": ":tiger2:",
@@ -3920,7 +3920,7 @@
     ]
   },
   "leopard": {
-    "unicode": "1F406",
+    "unicode": "1f406",
     "unicode_alternates": [],
     "name": "leopard",
     "shortname": ":leopard:",
@@ -3938,7 +3938,7 @@
     ]
   },
   "tiger": {
-    "unicode": "1F42F",
+    "unicode": "1f42f",
     "unicode_alternates": [],
     "name": "tiger face",
     "shortname": ":tiger:",
@@ -3957,7 +3957,7 @@
     ]
   },
   "chipmunk": {
-    "unicode": "1F43F",
+    "unicode": "1f43f",
     "unicode_alternates": [],
     "name": "chipmunk",
     "shortname": ":chipmunk:",
@@ -3971,7 +3971,7 @@
     ]
   },
   "rabbit2": {
-    "unicode": "1F407",
+    "unicode": "1f407",
     "unicode_alternates": [],
     "name": "rabbit",
     "shortname": ":rabbit2:",
@@ -3989,7 +3989,7 @@
     ]
   },
   "rabbit": {
-    "unicode": "1F430",
+    "unicode": "1f430",
     "unicode_alternates": [],
     "name": "rabbit face",
     "shortname": ":rabbit:",
@@ -4007,7 +4007,7 @@
     ]
   },
   "cat2": {
-    "unicode": "1F408",
+    "unicode": "1f408",
     "unicode_alternates": [],
     "name": "cat",
     "shortname": ":cat2:",
@@ -4023,7 +4023,7 @@
     ]
   },
   "cat": {
-    "unicode": "1F431",
+    "unicode": "1f431",
     "unicode_alternates": [],
     "name": "cat face",
     "shortname": ":cat:",
@@ -4039,7 +4039,7 @@
     ]
   },
   "racehorse": {
-    "unicode": "1F40E",
+    "unicode": "1f40e",
     "unicode_alternates": [],
     "name": "horse",
     "shortname": ":racehorse:",
@@ -4071,7 +4071,7 @@
     ]
   },
   "horse": {
-    "unicode": "1F434",
+    "unicode": "1f434",
     "unicode_alternates": [],
     "name": "horse face",
     "shortname": ":horse:",
@@ -4094,7 +4094,7 @@
     ]
   },
   "ram": {
-    "unicode": "1F40F",
+    "unicode": "1f40f",
     "unicode_alternates": [],
     "name": "ram",
     "shortname": ":ram:",
@@ -4111,7 +4111,7 @@
     ]
   },
   "sheep": {
-    "unicode": "1F411",
+    "unicode": "1f411",
     "unicode_alternates": [],
     "name": "sheep",
     "shortname": ":sheep:",
@@ -4131,7 +4131,7 @@
     ]
   },
   "goat": {
-    "unicode": "1F410",
+    "unicode": "1f410",
     "unicode_alternates": [],
     "name": "goat",
     "shortname": ":goat:",
@@ -4148,7 +4148,7 @@
     ]
   },
   "rooster": {
-    "unicode": "1F413",
+    "unicode": "1f413",
     "unicode_alternates": [],
     "name": "rooster",
     "shortname": ":rooster:",
@@ -4168,7 +4168,7 @@
     ]
   },
   "chicken": {
-    "unicode": "1F414",
+    "unicode": "1f414",
     "unicode_alternates": [],
     "name": "chicken",
     "shortname": ":chicken:",
@@ -4185,7 +4185,7 @@
     ]
   },
   "baby_chick": {
-    "unicode": "1F424",
+    "unicode": "1f424",
     "unicode_alternates": [],
     "name": "baby chick",
     "shortname": ":baby_chick:",
@@ -4203,7 +4203,7 @@
     ]
   },
   "hatching_chick": {
-    "unicode": "1F423",
+    "unicode": "1f423",
     "unicode_alternates": [],
     "name": "hatching chick",
     "shortname": ":hatching_chick:",
@@ -4224,7 +4224,7 @@
     ]
   },
   "hatched_chick": {
-    "unicode": "1F425",
+    "unicode": "1f425",
     "unicode_alternates": [],
     "name": "front-facing baby chick",
     "shortname": ":hatched_chick:",
@@ -4245,7 +4245,7 @@
     ]
   },
   "bird": {
-    "unicode": "1F426",
+    "unicode": "1f426",
     "unicode_alternates": [],
     "name": "bird",
     "shortname": ":bird:",
@@ -4261,7 +4261,7 @@
     ]
   },
   "penguin": {
-    "unicode": "1F427",
+    "unicode": "1f427",
     "unicode_alternates": [],
     "name": "penguin",
     "shortname": ":penguin:",
@@ -4276,7 +4276,7 @@
     ]
   },
   "elephant": {
-    "unicode": "1F418",
+    "unicode": "1f418",
     "unicode_alternates": [],
     "name": "elephant",
     "shortname": ":elephant:",
@@ -4292,7 +4292,7 @@
     ]
   },
   "dromedary_camel": {
-    "unicode": "1F42A",
+    "unicode": "1f42a",
     "unicode_alternates": [],
     "name": "dromedary camel",
     "shortname": ":dromedary_camel:",
@@ -4314,7 +4314,7 @@
     ]
   },
   "camel": {
-    "unicode": "1F42B",
+    "unicode": "1f42b",
     "unicode_alternates": [],
     "name": "bactrian camel",
     "shortname": ":camel:",
@@ -4337,7 +4337,7 @@
     ]
   },
   "boar": {
-    "unicode": "1F417",
+    "unicode": "1f417",
     "unicode_alternates": [],
     "name": "boar",
     "shortname": ":boar:",
@@ -4351,7 +4351,7 @@
     ]
   },
   "pig2": {
-    "unicode": "1F416",
+    "unicode": "1f416",
     "unicode_alternates": [],
     "name": "pig",
     "shortname": ":pig2:",
@@ -4376,7 +4376,7 @@
     ]
   },
   "pig": {
-    "unicode": "1F437",
+    "unicode": "1f437",
     "unicode_alternates": [],
     "name": "pig face",
     "shortname": ":pig:",
@@ -4401,7 +4401,7 @@
     ]
   },
   "pig_nose": {
-    "unicode": "1F43D",
+    "unicode": "1f43d",
     "unicode_alternates": [],
     "name": "pig nose",
     "shortname": ":pig_nose:",
@@ -4422,7 +4422,7 @@
     ]
   },
   "dog2": {
-    "unicode": "1F415",
+    "unicode": "1f415",
     "unicode_alternates": [],
     "name": "dog",
     "shortname": ":dog2:",
@@ -4442,7 +4442,7 @@
     ]
   },
   "poodle": {
-    "unicode": "1F429",
+    "unicode": "1f429",
     "unicode_alternates": [],
     "name": "poodle",
     "shortname": ":poodle:",
@@ -4461,7 +4461,7 @@
     ]
   },
   "dog": {
-    "unicode": "1F436",
+    "unicode": "1f436",
     "unicode_alternates": [],
     "name": "dog face",
     "shortname": ":dog:",
@@ -4481,7 +4481,7 @@
     ]
   },
   "wolf": {
-    "unicode": "1F43A",
+    "unicode": "1f43a",
     "unicode_alternates": [],
     "name": "wolf face",
     "shortname": ":wolf:",
@@ -4495,7 +4495,7 @@
     ]
   },
   "bear": {
-    "unicode": "1F43B",
+    "unicode": "1f43b",
     "unicode_alternates": [],
     "name": "bear face",
     "shortname": ":bear:",
@@ -4510,7 +4510,7 @@
     ]
   },
   "koala": {
-    "unicode": "1F428",
+    "unicode": "1f428",
     "unicode_alternates": [],
     "name": "koala",
     "shortname": ":koala:",
@@ -4524,7 +4524,7 @@
     ]
   },
   "panda_face": {
-    "unicode": "1F43C",
+    "unicode": "1f43c",
     "unicode_alternates": [],
     "name": "panda face",
     "shortname": ":panda_face:",
@@ -4548,7 +4548,7 @@
     ]
   },
   "monkey_face": {
-    "unicode": "1F435",
+    "unicode": "1f435",
     "unicode_alternates": [],
     "name": "monkey face",
     "shortname": ":monkey_face:",
@@ -4562,7 +4562,7 @@
     ]
   },
   "see_no_evil": {
-    "unicode": "1F648",
+    "unicode": "1f648",
     "unicode_alternates": [],
     "name": "see-no-evil monkey",
     "shortname": ":see_no_evil:",
@@ -4582,7 +4582,7 @@
     ]
   },
   "hear_no_evil": {
-    "unicode": "1F649",
+    "unicode": "1f649",
     "unicode_alternates": [],
     "name": "hear-no-evil monkey",
     "shortname": ":hear_no_evil:",
@@ -4599,7 +4599,7 @@
     ]
   },
   "speak_no_evil": {
-    "unicode": "1F64A",
+    "unicode": "1f64a",
     "unicode_alternates": [],
     "name": "speak-no-evil monkey",
     "shortname": ":speak_no_evil:",
@@ -4620,7 +4620,7 @@
     ]
   },
   "monkey": {
-    "unicode": "1F412",
+    "unicode": "1f412",
     "unicode_alternates": [],
     "name": "monkey",
     "shortname": ":monkey:",
@@ -4637,7 +4637,7 @@
     ]
   },
   "dragon": {
-    "unicode": "1F409",
+    "unicode": "1f409",
     "unicode_alternates": [],
     "name": "dragon",
     "shortname": ":dragon:",
@@ -4657,7 +4657,7 @@
     ]
   },
   "dragon_face": {
-    "unicode": "1F432",
+    "unicode": "1f432",
     "unicode_alternates": [],
     "name": "dragon face",
     "shortname": ":dragon_face:",
@@ -4678,7 +4678,7 @@
     ]
   },
   "crocodile": {
-    "unicode": "1F40A",
+    "unicode": "1f40a",
     "unicode_alternates": [],
     "name": "crocodile",
     "shortname": ":crocodile:",
@@ -4696,7 +4696,7 @@
     ]
   },
   "snake": {
-    "unicode": "1F40D",
+    "unicode": "1f40d",
     "unicode_alternates": [],
     "name": "snake",
     "shortname": ":snake:",
@@ -4710,7 +4710,7 @@
     ]
   },
   "turtle": {
-    "unicode": "1F422",
+    "unicode": "1f422",
     "unicode_alternates": [],
     "name": "turtle",
     "shortname": ":turtle:",
@@ -4731,7 +4731,7 @@
     ]
   },
   "frog": {
-    "unicode": "1F438",
+    "unicode": "1f438",
     "unicode_alternates": [],
     "name": "frog face",
     "shortname": ":frog:",
@@ -4745,7 +4745,7 @@
     ]
   },
   "whale2": {
-    "unicode": "1F40B",
+    "unicode": "1f40b",
     "unicode_alternates": [],
     "name": "whale",
     "shortname": ":whale2:",
@@ -4766,7 +4766,7 @@
     ]
   },
   "whale": {
-    "unicode": "1F433",
+    "unicode": "1f433",
     "unicode_alternates": [],
     "name": "spouting whale",
     "shortname": ":whale:",
@@ -4782,7 +4782,7 @@
     ]
   },
   "dolphin": {
-    "unicode": "1F42C",
+    "unicode": "1f42c",
     "unicode_alternates": [],
     "name": "dolphin",
     "shortname": ":dolphin:",
@@ -4801,7 +4801,7 @@
     ]
   },
   "octopus": {
-    "unicode": "1F419",
+    "unicode": "1f419",
     "unicode_alternates": [],
     "name": "octopus",
     "shortname": ":octopus:",
@@ -4817,7 +4817,7 @@
     ]
   },
   "fish": {
-    "unicode": "1F41F",
+    "unicode": "1f41f",
     "unicode_alternates": [],
     "name": "fish",
     "shortname": ":fish:",
@@ -4832,7 +4832,7 @@
     ]
   },
   "tropical_fish": {
-    "unicode": "1F420",
+    "unicode": "1f420",
     "unicode_alternates": [],
     "name": "tropical fish",
     "shortname": ":tropical_fish:",
@@ -4846,7 +4846,7 @@
     ]
   },
   "blowfish": {
-    "unicode": "1F421",
+    "unicode": "1f421",
     "unicode_alternates": [],
     "name": "blowfish",
     "shortname": ":blowfish:",
@@ -4866,7 +4866,7 @@
     ]
   },
   "shell": {
-    "unicode": "1F41A",
+    "unicode": "1f41a",
     "unicode_alternates": [],
     "name": "spiral shell",
     "shortname": ":shell:",
@@ -4885,7 +4885,7 @@
     ]
   },
   "snail": {
-    "unicode": "1F40C",
+    "unicode": "1f40c",
     "unicode_alternates": [],
     "name": "snail",
     "shortname": ":snail:",
@@ -4904,7 +4904,7 @@
     ]
   },
   "bug": {
-    "unicode": "1F41B",
+    "unicode": "1f41b",
     "unicode_alternates": [],
     "name": "bug",
     "shortname": ":bug:",
@@ -4921,7 +4921,7 @@
     ]
   },
   "ant": {
-    "unicode": "1F41C",
+    "unicode": "1f41c",
     "unicode_alternates": [],
     "name": "ant",
     "shortname": ":ant:",
@@ -4937,7 +4937,7 @@
     ]
   },
   "bee": {
-    "unicode": "1F41D",
+    "unicode": "1f41d",
     "unicode_alternates": [],
     "name": "honeybee",
     "shortname": ":bee:",
@@ -4960,7 +4960,7 @@
     ]
   },
   "beetle": {
-    "unicode": "1F41E",
+    "unicode": "1f41e",
     "unicode_alternates": [],
     "name": "lady beetle",
     "shortname": ":beetle:",
@@ -4980,7 +4980,7 @@
     ]
   },
   "spider": {
-    "unicode": "1F577",
+    "unicode": "1f577",
     "unicode_alternates": [],
     "name": "spider",
     "shortname": ":spider:",
@@ -4994,7 +4994,7 @@
     ]
   },
   "spider_web": {
-    "unicode": "1F578",
+    "unicode": "1f578",
     "unicode_alternates": [],
     "name": "spider web",
     "shortname": ":spider_web:",
@@ -5007,7 +5007,7 @@
     ]
   },
   "feet": {
-    "unicode": "1F43E",
+    "unicode": "1f43e",
     "unicode_alternates": [],
     "name": "paw prints",
     "shortname": ":feet:",
@@ -5032,7 +5032,7 @@
     ]
   },
   "zap": {
-    "unicode": "26A1",
+    "unicode": "26a1",
     "unicode_alternates": [
       "26A1-FE0F"
     ],
@@ -5050,7 +5050,7 @@
     ]
   },
   "fire": {
-    "unicode": "1F525",
+    "unicode": "1f525",
     "unicode_alternates": [],
     "name": "fire",
     "shortname": ":fire:",
@@ -5067,7 +5067,7 @@
     ]
   },
   "crescent_moon": {
-    "unicode": "1F319",
+    "unicode": "1f319",
     "unicode_alternates": [],
     "name": "crescent moon",
     "shortname": ":crescent_moon:",
@@ -5102,7 +5102,7 @@
     ]
   },
   "partly_sunny": {
-    "unicode": "26C5",
+    "unicode": "26c5",
     "unicode_alternates": [
       "26C5-FE0F"
     ],
@@ -5137,7 +5137,7 @@
     ]
   },
   "cloud_rain": {
-    "unicode": "1F327",
+    "unicode": "1f327",
     "unicode_alternates": [],
     "name": "cloud with rain",
     "shortname": ":cloud_rain:",
@@ -5153,7 +5153,7 @@
     ]
   },
   "cloud_snow": {
-    "unicode": "1F328",
+    "unicode": "1f328",
     "unicode_alternates": [],
     "name": "cloud with snow",
     "shortname": ":cloud_snow:",
@@ -5169,7 +5169,7 @@
     ]
   },
   "cloud_lightning": {
-    "unicode": "1F329",
+    "unicode": "1f329",
     "unicode_alternates": [],
     "name": "cloud with lightning",
     "shortname": ":cloud_lightning:",
@@ -5185,7 +5185,7 @@
     ]
   },
   "cloud_tornado": {
-    "unicode": "1F32A",
+    "unicode": "1f32a",
     "unicode_alternates": [],
     "name": "cloud with tornado",
     "shortname": ":cloud_tornado:",
@@ -5202,7 +5202,7 @@
     ]
   },
   "droplet": {
-    "unicode": "1F4A7",
+    "unicode": "1f4a7",
     "unicode_alternates": [],
     "name": "droplet",
     "shortname": ":droplet:",
@@ -5227,7 +5227,7 @@
     ]
   },
   "sweat_drops": {
-    "unicode": "1F4A6",
+    "unicode": "1f4a6",
     "unicode_alternates": [],
     "name": "splashing sweat symbol",
     "shortname": ":sweat_drops:",
@@ -5257,7 +5257,7 @@
     ]
   },
   "fog": {
-    "unicode": "1F32B",
+    "unicode": "1f32b",
     "unicode_alternates": [],
     "name": "fog",
     "shortname": ":fog:",
@@ -5273,7 +5273,7 @@
     ]
   },
   "dash": {
-    "unicode": "1F4A8",
+    "unicode": "1f4a8",
     "unicode_alternates": [],
     "name": "dash symbol",
     "shortname": ":dash:",
@@ -5319,7 +5319,7 @@
     ]
   },
   "star2": {
-    "unicode": "1F31F",
+    "unicode": "1f31f",
     "unicode_alternates": [],
     "name": "glowing star",
     "shortname": ":star2:",
@@ -5337,7 +5337,7 @@
     ]
   },
   "star": {
-    "unicode": "2B50",
+    "unicode": "2b50",
     "unicode_alternates": [
       "2B50-FE0F"
     ],
@@ -5353,7 +5353,7 @@
     ]
   },
   "stars": {
-    "unicode": "1F320",
+    "unicode": "1f320",
     "unicode_alternates": [],
     "name": "shooting star",
     "shortname": ":stars:",
@@ -5370,7 +5370,7 @@
     ]
   },
   "sunrise_over_mountains": {
-    "unicode": "1F304",
+    "unicode": "1f304",
     "unicode_alternates": [],
     "name": "sunrise over mountains",
     "shortname": ":sunrise_over_mountains:",
@@ -5389,7 +5389,7 @@
     ]
   },
   "sunrise": {
-    "unicode": "1F305",
+    "unicode": "1f305",
     "unicode_alternates": [],
     "name": "sunrise",
     "shortname": ":sunrise:",
@@ -5408,7 +5408,7 @@
     ]
   },
   "rainbow": {
-    "unicode": "1F308",
+    "unicode": "1f308",
     "unicode_alternates": [],
     "name": "rainbow",
     "shortname": ":rainbow:",
@@ -5431,7 +5431,7 @@
     ]
   },
   "ocean": {
-    "unicode": "1F30A",
+    "unicode": "1f30a",
     "unicode_alternates": [],
     "name": "water wave",
     "shortname": ":ocean:",
@@ -5448,7 +5448,7 @@
     ]
   },
   "volcano": {
-    "unicode": "1F30B",
+    "unicode": "1f30b",
     "unicode_alternates": [],
     "name": "volcano",
     "shortname": ":volcano:",
@@ -5466,7 +5466,7 @@
     ]
   },
   "milky_way": {
-    "unicode": "1F30C",
+    "unicode": "1f30c",
     "unicode_alternates": [],
     "name": "milky way",
     "shortname": ":milky_way:",
@@ -5484,7 +5484,7 @@
     ]
   },
   "mount_fuji": {
-    "unicode": "1F5FB",
+    "unicode": "1f5fb",
     "unicode_alternates": [],
     "name": "mount fuji",
     "shortname": ":mount_fuji:",
@@ -5500,7 +5500,7 @@
     ]
   },
   "japan": {
-    "unicode": "1F5FE",
+    "unicode": "1f5fe",
     "unicode_alternates": [],
     "name": "silhouette of japan",
     "shortname": ":japan:",
@@ -5514,7 +5514,7 @@
     ]
   },
   "globe_with_meridians": {
-    "unicode": "1F310",
+    "unicode": "1f310",
     "unicode_alternates": [],
     "name": "globe with meridians",
     "shortname": ":globe_with_meridians:",
@@ -5531,7 +5531,7 @@
     ]
   },
   "earth_africa": {
-    "unicode": "1F30D",
+    "unicode": "1f30d",
     "unicode_alternates": [],
     "name": "earth globe europe-africa",
     "shortname": ":earth_africa:",
@@ -5550,7 +5550,7 @@
     ]
   },
   "earth_americas": {
-    "unicode": "1F30E",
+    "unicode": "1f30e",
     "unicode_alternates": [],
     "name": "earth globe americas",
     "shortname": ":earth_americas:",
@@ -5570,7 +5570,7 @@
     ]
   },
   "earth_asia": {
-    "unicode": "1F30F",
+    "unicode": "1f30f",
     "unicode_alternates": [],
     "name": "earth globe asia-australia",
     "shortname": ":earth_asia:",
@@ -5590,7 +5590,7 @@
     ]
   },
   "new_moon": {
-    "unicode": "1F311",
+    "unicode": "1f311",
     "unicode_alternates": [],
     "name": "new moon symbol",
     "shortname": ":new_moon:",
@@ -5607,7 +5607,7 @@
     ]
   },
   "waxing_crescent_moon": {
-    "unicode": "1F312",
+    "unicode": "1f312",
     "unicode_alternates": [],
     "name": "waxing crescent moon symbol",
     "shortname": ":waxing_crescent_moon:",
@@ -5624,7 +5624,7 @@
     ]
   },
   "first_quarter_moon": {
-    "unicode": "1F313",
+    "unicode": "1f313",
     "unicode_alternates": [],
     "name": "first quarter moon symbol",
     "shortname": ":first_quarter_moon:",
@@ -5641,7 +5641,7 @@
     ]
   },
   "waxing_gibbous_moon": {
-    "unicode": "1F314",
+    "unicode": "1f314",
     "unicode_alternates": [],
     "name": "waxing gibbous moon symbol",
     "shortname": ":waxing_gibbous_moon:",
@@ -5658,7 +5658,7 @@
     ]
   },
   "full_moon": {
-    "unicode": "1F315",
+    "unicode": "1f315",
     "unicode_alternates": [],
     "name": "full moon symbol",
     "shortname": ":full_moon:",
@@ -5679,7 +5679,7 @@
     ]
   },
   "waning_gibbous_moon": {
-    "unicode": "1F316",
+    "unicode": "1f316",
     "unicode_alternates": [],
     "name": "waning gibbous moon symbol",
     "shortname": ":waning_gibbous_moon:",
@@ -5696,7 +5696,7 @@
     ]
   },
   "last_quarter_moon": {
-    "unicode": "1F317",
+    "unicode": "1f317",
     "unicode_alternates": [],
     "name": "last quarter moon symbol",
     "shortname": ":last_quarter_moon:",
@@ -5713,7 +5713,7 @@
     ]
   },
   "waning_crescent_moon": {
-    "unicode": "1F318",
+    "unicode": "1f318",
     "unicode_alternates": [],
     "name": "waning crescent moon symbol",
     "shortname": ":waning_crescent_moon:",
@@ -5730,7 +5730,7 @@
     ]
   },
   "new_moon_with_face": {
-    "unicode": "1F31A",
+    "unicode": "1f31a",
     "unicode_alternates": [],
     "name": "new moon with face",
     "shortname": ":new_moon_with_face:",
@@ -5748,7 +5748,7 @@
     ]
   },
   "full_moon_with_face": {
-    "unicode": "1F31D",
+    "unicode": "1f31d",
     "unicode_alternates": [],
     "name": "full moon with face",
     "shortname": ":full_moon_with_face:",
@@ -5768,7 +5768,7 @@
     ]
   },
   "first_quarter_moon_with_face": {
-    "unicode": "1F31B",
+    "unicode": "1f31b",
     "unicode_alternates": [],
     "name": "first quarter moon with face",
     "shortname": ":first_quarter_moon_with_face:",
@@ -5787,7 +5787,7 @@
     ]
   },
   "last_quarter_moon_with_face": {
-    "unicode": "1F31C",
+    "unicode": "1f31c",
     "unicode_alternates": [],
     "name": "last quarter moon with face",
     "shortname": ":last_quarter_moon_with_face:",
@@ -5806,7 +5806,7 @@
     ]
   },
   "sun_with_face": {
-    "unicode": "1F31E",
+    "unicode": "1f31e",
     "unicode_alternates": [],
     "name": "sun with face",
     "shortname": ":sun_with_face:",
@@ -5823,7 +5823,7 @@
     ]
   },
   "wind_blowing_face": {
-    "unicode": "1F32C",
+    "unicode": "1f32c",
     "unicode_alternates": [],
     "name": "wind blowing face",
     "shortname": ":wind_blowing_face:",
@@ -5837,7 +5837,7 @@
     ]
   },
   "ribbon": {
-    "unicode": "1F380",
+    "unicode": "1f380",
     "unicode_alternates": [],
     "name": "ribbon",
     "shortname": ":ribbon:",
@@ -5855,7 +5855,7 @@
     ]
   },
   "gift": {
-    "unicode": "1F381",
+    "unicode": "1f381",
     "unicode_alternates": [],
     "name": "wrapped present",
     "shortname": ":gift:",
@@ -5873,7 +5873,7 @@
     ]
   },
   "birthday": {
-    "unicode": "1F382",
+    "unicode": "1f382",
     "unicode_alternates": [],
     "name": "birthday cake",
     "shortname": ":birthday:",
@@ -5890,7 +5890,7 @@
     ]
   },
   "jack_o_lantern": {
-    "unicode": "1F383",
+    "unicode": "1f383",
     "unicode_alternates": [],
     "name": "jack-o-lantern",
     "shortname": ":jack_o_lantern:",
@@ -5916,7 +5916,7 @@
     ]
   },
   "christmas_tree": {
-    "unicode": "1F384",
+    "unicode": "1f384",
     "unicode_alternates": [],
     "name": "christmas tree",
     "shortname": ":christmas_tree:",
@@ -5941,7 +5941,7 @@
     ]
   },
   "tanabata_tree": {
-    "unicode": "1F38B",
+    "unicode": "1f38b",
     "unicode_alternates": [],
     "name": "tanabata tree",
     "shortname": ":tanabata_tree:",
@@ -5959,7 +5959,7 @@
     ]
   },
   "bamboo": {
-    "unicode": "1F38D",
+    "unicode": "1f38d",
     "unicode_alternates": [],
     "name": "pine decoration",
     "shortname": ":bamboo:",
@@ -5986,7 +5986,7 @@
     ]
   },
   "rice_scene": {
-    "unicode": "1F391",
+    "unicode": "1f391",
     "unicode_alternates": [],
     "name": "moon viewing ceremony",
     "shortname": ":rice_scene:",
@@ -6005,7 +6005,7 @@
     ]
   },
   "fireworks": {
-    "unicode": "1F386",
+    "unicode": "1f386",
     "unicode_alternates": [],
     "name": "fireworks",
     "shortname": ":fireworks:",
@@ -6029,7 +6029,7 @@
     ]
   },
   "sparkler": {
-    "unicode": "1F387",
+    "unicode": "1f387",
     "unicode_alternates": [],
     "name": "firework sparkler",
     "shortname": ":sparkler:",
@@ -6044,7 +6044,7 @@
     ]
   },
   "tada": {
-    "unicode": "1F389",
+    "unicode": "1f389",
     "unicode_alternates": [],
     "name": "party popper",
     "shortname": ":tada:",
@@ -6062,7 +6062,7 @@
     ]
   },
   "confetti_ball": {
-    "unicode": "1F38A",
+    "unicode": "1f38a",
     "unicode_alternates": [],
     "name": "confetti ball",
     "shortname": ":confetti_ball:",
@@ -6082,7 +6082,7 @@
     ]
   },
   "balloon": {
-    "unicode": "1F388",
+    "unicode": "1f388",
     "unicode_alternates": [],
     "name": "balloon",
     "shortname": ":balloon:",
@@ -6101,7 +6101,7 @@
     ]
   },
   "dizzy": {
-    "unicode": "1F4AB",
+    "unicode": "1f4ab",
     "unicode_alternates": [],
     "name": "dizzy symbol",
     "shortname": ":dizzy:",
@@ -6138,7 +6138,7 @@
     ]
   },
   "boom": {
-    "unicode": "1F4A5",
+    "unicode": "1f4a5",
     "unicode_alternates": [],
     "name": "collision symbol",
     "shortname": ":boom:",
@@ -6159,7 +6159,7 @@
     ]
   },
   "mortar_board": {
-    "unicode": "1F393",
+    "unicode": "1f393",
     "unicode_alternates": [],
     "name": "graduation cap",
     "shortname": ":mortar_board:",
@@ -6181,7 +6181,7 @@
     ]
   },
   "crown": {
-    "unicode": "1F451",
+    "unicode": "1f451",
     "unicode_alternates": [],
     "name": "crown",
     "shortname": ":crown:",
@@ -6197,7 +6197,7 @@
     ]
   },
   "reminder_ribbon": {
-    "unicode": "1F397",
+    "unicode": "1f397",
     "unicode_alternates": [],
     "name": "reminder ribbon",
     "shortname": ":reminder_ribbon:",
@@ -6210,7 +6210,7 @@
     ]
   },
   "military_medal": {
-    "unicode": "1F396",
+    "unicode": "1f396",
     "unicode_alternates": [],
     "name": "military medal",
     "shortname": ":military_medal:",
@@ -6227,7 +6227,7 @@
     ]
   },
   "dolls": {
-    "unicode": "1F38E",
+    "unicode": "1f38e",
     "unicode_alternates": [],
     "name": "japanese dolls",
     "shortname": ":dolls:",
@@ -6251,7 +6251,7 @@
     ]
   },
   "flags": {
-    "unicode": "1F38F",
+    "unicode": "1f38f",
     "unicode_alternates": [],
     "name": "carp streamer",
     "shortname": ":flags:",
@@ -6274,7 +6274,7 @@
     ]
   },
   "wind_chime": {
-    "unicode": "1F390",
+    "unicode": "1f390",
     "unicode_alternates": [],
     "name": "wind chime",
     "shortname": ":wind_chime:",
@@ -6297,7 +6297,7 @@
     ]
   },
   "crossed_flags": {
-    "unicode": "1F38C",
+    "unicode": "1f38c",
     "unicode_alternates": [],
     "name": "crossed flags",
     "shortname": ":crossed_flags:",
@@ -6310,7 +6310,7 @@
     ]
   },
   "izakaya_lantern": {
-    "unicode": "1F3EE",
+    "unicode": "1f3ee",
     "unicode_alternates": [],
     "name": "izakaya lantern",
     "shortname": ":izakaya_lantern:",
@@ -6329,7 +6329,7 @@
     ]
   },
   "ring": {
-    "unicode": "1F48D",
+    "unicode": "1f48d",
     "unicode_alternates": [],
     "name": "ring",
     "shortname": ":ring:",
@@ -6347,7 +6347,7 @@
     ]
   },
   "bouquet2": {
-    "unicode": "1F395",
+    "unicode": "1f395",
     "unicode_alternates": [],
     "name": "bouquet of flowers",
     "shortname": ":bouquet2:",
@@ -6393,7 +6393,7 @@
     ]
   },
   "broken_heart": {
-    "unicode": "1F494",
+    "unicode": "1f494",
     "unicode_alternates": [],
     "name": "broken heart",
     "shortname": ":broken_heart:",
@@ -6411,7 +6411,7 @@
     ]
   },
   "love_letter": {
-    "unicode": "1F48C",
+    "unicode": "1f48c",
     "unicode_alternates": [],
     "name": "love letter",
     "shortname": ":love_letter:",
@@ -6430,7 +6430,7 @@
     ]
   },
   "two_hearts": {
-    "unicode": "1F495",
+    "unicode": "1f495",
     "unicode_alternates": [],
     "name": "two hearts",
     "shortname": ":two_hearts:",
@@ -6447,7 +6447,7 @@
     ]
   },
   "revolving_hearts": {
-    "unicode": "1F49E",
+    "unicode": "1f49e",
     "unicode_alternates": [],
     "name": "revolving hearts",
     "shortname": ":revolving_hearts:",
@@ -6464,7 +6464,7 @@
     ]
   },
   "heartbeat": {
-    "unicode": "1F493",
+    "unicode": "1f493",
     "unicode_alternates": [],
     "name": "beating heart",
     "shortname": ":heartbeat:",
@@ -6480,7 +6480,7 @@
     ]
   },
   "heartpulse": {
-    "unicode": "1F497",
+    "unicode": "1f497",
     "unicode_alternates": [],
     "name": "growing heart",
     "shortname": ":heartpulse:",
@@ -6496,7 +6496,7 @@
     ]
   },
   "sparkling_heart": {
-    "unicode": "1F496",
+    "unicode": "1f496",
     "unicode_alternates": [],
     "name": "sparkling heart",
     "shortname": ":sparkling_heart:",
@@ -6512,7 +6512,7 @@
     ]
   },
   "cupid": {
-    "unicode": "1F498",
+    "unicode": "1f498",
     "unicode_alternates": [],
     "name": "heart with arrow",
     "shortname": ":cupid:",
@@ -6528,7 +6528,7 @@
     ]
   },
   "gift_heart": {
-    "unicode": "1F49D",
+    "unicode": "1f49d",
     "unicode_alternates": [],
     "name": "heart with ribbon",
     "shortname": ":gift_heart:",
@@ -6543,7 +6543,7 @@
     ]
   },
   "heart_tip": {
-    "unicode": "1F394",
+    "unicode": "1f394",
     "unicode_alternates": [],
     "name": "heart with tip on the left",
     "shortname": ":heart_tip:",
@@ -6561,7 +6561,7 @@
     ]
   },
   "heart_decoration": {
-    "unicode": "1F49F",
+    "unicode": "1f49f",
     "unicode_alternates": [],
     "name": "heart decoration",
     "shortname": ":heart_decoration:",
@@ -6576,7 +6576,7 @@
     ]
   },
   "purple_heart": {
-    "unicode": "1F49C",
+    "unicode": "1f49c",
     "unicode_alternates": [],
     "name": "purple heart",
     "shortname": ":purple_heart:",
@@ -6603,7 +6603,7 @@
     ]
   },
   "yellow_heart": {
-    "unicode": "1F49B",
+    "unicode": "1f49b",
     "unicode_alternates": [],
     "name": "yellow heart",
     "shortname": ":yellow_heart:",
@@ -6629,7 +6629,7 @@
     ]
   },
   "green_heart": {
-    "unicode": "1F49A",
+    "unicode": "1f49a",
     "unicode_alternates": [],
     "name": "green heart",
     "shortname": ":green_heart:",
@@ -6652,7 +6652,7 @@
     ]
   },
   "blue_heart": {
-    "unicode": "1F499",
+    "unicode": "1f499",
     "unicode_alternates": [],
     "name": "blue heart",
     "shortname": ":blue_heart:",
@@ -6672,7 +6672,7 @@
     ]
   },
   "runner": {
-    "unicode": "1F3C3",
+    "unicode": "1f3c3",
     "unicode_alternates": [],
     "name": "runner",
     "shortname": ":runner:",
@@ -6692,7 +6692,7 @@
     ]
   },
   "walking": {
-    "unicode": "1F6B6",
+    "unicode": "1f6b6",
     "unicode_alternates": [],
     "name": "pedestrian",
     "shortname": ":walking:",
@@ -6710,7 +6710,7 @@
     ]
   },
   "dancer": {
-    "unicode": "1F483",
+    "unicode": "1f483",
     "unicode_alternates": [],
     "name": "dancer",
     "shortname": ":dancer:",
@@ -6735,7 +6735,7 @@
     ]
   },
   "lifter": {
-    "unicode": "1F3CB",
+    "unicode": "1f3cb",
     "unicode_alternates": [],
     "name": "weight lifter",
     "shortname": ":lifter:",
@@ -6753,7 +6753,7 @@
     ]
   },
   "golfer": {
-    "unicode": "1F3CC",
+    "unicode": "1f3cc",
     "unicode_alternates": [],
     "name": "golfer",
     "shortname": ":golfer:",
@@ -6770,7 +6770,7 @@
     ]
   },
   "rowboat": {
-    "unicode": "1F6A3",
+    "unicode": "1f6a3",
     "unicode_alternates": [],
     "name": "rowboat",
     "shortname": ":rowboat:",
@@ -6789,7 +6789,7 @@
     ]
   },
   "swimmer": {
-    "unicode": "1F3CA",
+    "unicode": "1f3ca",
     "unicode_alternates": [],
     "name": "swimmer",
     "shortname": ":swimmer:",
@@ -6810,7 +6810,7 @@
     ]
   },
   "surfer": {
-    "unicode": "1F3C4",
+    "unicode": "1f3c4",
     "unicode_alternates": [],
     "name": "surfer",
     "shortname": ":surfer:",
@@ -6830,7 +6830,7 @@
     ]
   },
   "bath": {
-    "unicode": "1F6C0",
+    "unicode": "1f6c0",
     "unicode_alternates": [],
     "name": "bath",
     "shortname": ":bath:",
@@ -6854,7 +6854,7 @@
     ]
   },
   "snowboarder": {
-    "unicode": "1F3C2",
+    "unicode": "1f3c2",
     "unicode_alternates": [],
     "name": "snowboarder",
     "shortname": ":snowboarder:",
@@ -6875,7 +6875,7 @@
     ]
   },
   "ski": {
-    "unicode": "1F3BF",
+    "unicode": "1f3bf",
     "unicode_alternates": [],
     "name": "ski and ski boot",
     "shortname": ":ski:",
@@ -6899,7 +6899,7 @@
     ]
   },
   "snowman": {
-    "unicode": "26C4",
+    "unicode": "26c4",
     "unicode_alternates": [
       "26C4-FE0F"
     ],
@@ -6919,7 +6919,7 @@
     ]
   },
   "bicyclist": {
-    "unicode": "1F6B4",
+    "unicode": "1f6b4",
     "unicode_alternates": [],
     "name": "bicyclist",
     "shortname": ":bicyclist:",
@@ -6939,7 +6939,7 @@
     ]
   },
   "mountain_bicyclist": {
-    "unicode": "1F6B5",
+    "unicode": "1f6b5",
     "unicode_alternates": [],
     "name": "mountain bicyclist",
     "shortname": ":mountain_bicyclist:",
@@ -6957,7 +6957,7 @@
     ]
   },
   "motorcycle": {
-    "unicode": "1F3CD",
+    "unicode": "1f3cd",
     "unicode_alternates": [],
     "name": "racing motorcycle",
     "shortname": ":motorcycle:",
@@ -6973,7 +6973,7 @@
     ]
   },
   "race_car": {
-    "unicode": "1F3CE",
+    "unicode": "1f3ce",
     "unicode_alternates": [],
     "name": "racing car",
     "shortname": ":race_car:",
@@ -6993,7 +6993,7 @@
     ]
   },
   "horse_racing": {
-    "unicode": "1F3C7",
+    "unicode": "1f3c7",
     "unicode_alternates": [],
     "name": "horse racing",
     "shortname": ":horse_racing:",
@@ -7011,7 +7011,7 @@
     ]
   },
   "tent": {
-    "unicode": "26FA",
+    "unicode": "26fa",
     "unicode_alternates": [
       "26FA-FE0F"
     ],
@@ -7028,7 +7028,7 @@
     ]
   },
   "fishing_pole_and_fish": {
-    "unicode": "1F3A3",
+    "unicode": "1f3a3",
     "unicode_alternates": [],
     "name": "fishing pole and fish",
     "shortname": ":fishing_pole_and_fish:",
@@ -7044,7 +7044,7 @@
     ]
   },
   "soccer": {
-    "unicode": "26BD",
+    "unicode": "26bd",
     "unicode_alternates": [
       "26BD-FE0F"
     ],
@@ -7062,7 +7062,7 @@
     ]
   },
   "basketball": {
-    "unicode": "1F3C0",
+    "unicode": "1f3c0",
     "unicode_alternates": [],
     "name": "basketball and hoop",
     "shortname": ":basketball:",
@@ -7083,7 +7083,7 @@
     ]
   },
   "football": {
-    "unicode": "1F3C8",
+    "unicode": "1f3c8",
     "unicode_alternates": [],
     "name": "american football",
     "shortname": ":football:",
@@ -7099,7 +7099,7 @@
     ]
   },
   "baseball": {
-    "unicode": "26BE",
+    "unicode": "26be",
     "unicode_alternates": [
       "26BE-FE0F"
     ],
@@ -7117,7 +7117,7 @@
     ]
   },
   "tennis": {
-    "unicode": "1F3BE",
+    "unicode": "1f3be",
     "unicode_alternates": [],
     "name": "tennis racquet and ball",
     "shortname": ":tennis:",
@@ -7137,7 +7137,7 @@
     ]
   },
   "rugby_football": {
-    "unicode": "1F3C9",
+    "unicode": "1f3c9",
     "unicode_alternates": [],
     "name": "rugby football",
     "shortname": ":rugby_football:",
@@ -7156,7 +7156,7 @@
     ]
   },
   "golf": {
-    "unicode": "26F3",
+    "unicode": "26f3",
     "unicode_alternates": [
       "26F3-FE0F"
     ],
@@ -7173,7 +7173,7 @@
     ]
   },
   "trophy": {
-    "unicode": "1F3C6",
+    "unicode": "1f3c6",
     "unicode_alternates": [],
     "name": "trophy",
     "shortname": ":trophy:",
@@ -7196,7 +7196,7 @@
     ]
   },
   "medal": {
-    "unicode": "1F3C5",
+    "unicode": "1f3c5",
     "unicode_alternates": [],
     "name": "sports medal",
     "shortname": ":medal:",
@@ -7220,7 +7220,7 @@
     ]
   },
   "running_shirt_with_sash": {
-    "unicode": "1F3BD",
+    "unicode": "1f3bd",
     "unicode_alternates": [],
     "name": "running shirt with sash",
     "shortname": ":running_shirt_with_sash:",
@@ -7238,7 +7238,7 @@
     ]
   },
   "checkered_flag": {
-    "unicode": "1F3C1",
+    "unicode": "1f3c1",
     "unicode_alternates": [],
     "name": "chequered flag",
     "shortname": ":checkered_flag:",
@@ -7259,7 +7259,7 @@
     ]
   },
   "musical_keyboard": {
-    "unicode": "1F3B9",
+    "unicode": "1f3b9",
     "unicode_alternates": [],
     "name": "musical keyboard",
     "shortname": ":musical_keyboard:",
@@ -7277,7 +7277,7 @@
     ]
   },
   "guitar": {
-    "unicode": "1F3B8",
+    "unicode": "1f3b8",
     "unicode_alternates": [],
     "name": "guitar",
     "shortname": ":guitar:",
@@ -7296,7 +7296,7 @@
     ]
   },
   "violin": {
-    "unicode": "1F3BB",
+    "unicode": "1f3bb",
     "unicode_alternates": [],
     "name": "violin",
     "shortname": ":violin:",
@@ -7312,7 +7312,7 @@
     ]
   },
   "saxophone": {
-    "unicode": "1F3B7",
+    "unicode": "1f3b7",
     "unicode_alternates": [],
     "name": "saxophone",
     "shortname": ":saxophone:",
@@ -7328,7 +7328,7 @@
     ]
   },
   "trumpet": {
-    "unicode": "1F3BA",
+    "unicode": "1f3ba",
     "unicode_alternates": [],
     "name": "trumpet",
     "shortname": ":trumpet:",
@@ -7343,7 +7343,7 @@
     ]
   },
   "musical_note": {
-    "unicode": "1F3B5",
+    "unicode": "1f3b5",
     "unicode_alternates": [],
     "name": "musical note",
     "shortname": ":musical_note:",
@@ -7359,7 +7359,7 @@
     ]
   },
   "notes": {
-    "unicode": "1F3B6",
+    "unicode": "1f3b6",
     "unicode_alternates": [],
     "name": "multiple musical notes",
     "shortname": ":notes:",
@@ -7376,7 +7376,7 @@
     ]
   },
   "musical_score": {
-    "unicode": "1F3BC",
+    "unicode": "1f3bc",
     "unicode_alternates": [],
     "name": "musical score",
     "shortname": ":musical_score:",
@@ -7395,7 +7395,7 @@
     ]
   },
   "headphones": {
-    "unicode": "1F3A7",
+    "unicode": "1f3a7",
     "unicode_alternates": [],
     "name": "headphone",
     "shortname": ":headphones:",
@@ -7416,7 +7416,7 @@
     ]
   },
   "microphone": {
-    "unicode": "1F3A4",
+    "unicode": "1f3a4",
     "unicode_alternates": [],
     "name": "microphone",
     "shortname": ":microphone:",
@@ -7435,7 +7435,7 @@
     ]
   },
   "performing_arts": {
-    "unicode": "1F3AD",
+    "unicode": "1f3ad",
     "unicode_alternates": [],
     "name": "performing arts",
     "shortname": ":performing_arts:",
@@ -7456,7 +7456,7 @@
     ]
   },
   "ticket": {
-    "unicode": "1F3AB",
+    "unicode": "1f3ab",
     "unicode_alternates": [],
     "name": "ticket",
     "shortname": ":ticket:",
@@ -7477,7 +7477,7 @@
     ]
   },
   "tophat": {
-    "unicode": "1F3A9",
+    "unicode": "1f3a9",
     "unicode_alternates": [],
     "name": "top hat",
     "shortname": ":tophat:",
@@ -7503,7 +7503,7 @@
     ]
   },
   "circus_tent": {
-    "unicode": "1F3AA",
+    "unicode": "1f3aa",
     "unicode_alternates": [],
     "name": "circus tent",
     "shortname": ":circus_tent:",
@@ -7522,7 +7522,7 @@
     ]
   },
   "clapper": {
-    "unicode": "1F3AC",
+    "unicode": "1f3ac",
     "unicode_alternates": [],
     "name": "clapper board",
     "shortname": ":clapper:",
@@ -7539,7 +7539,7 @@
     ]
   },
   "film_frames": {
-    "unicode": "1F39E",
+    "unicode": "1f39e",
     "unicode_alternates": [],
     "name": "film frames",
     "shortname": ":film_frames:",
@@ -7557,7 +7557,7 @@
     ]
   },
   "tickets": {
-    "unicode": "1F39F",
+    "unicode": "1f39f",
     "unicode_alternates": [],
     "name": "admission tickets",
     "shortname": ":tickets:",
@@ -7579,7 +7579,7 @@
     ]
   },
   "art": {
-    "unicode": "1F3A8",
+    "unicode": "1f3a8",
     "unicode_alternates": [],
     "name": "artist palette",
     "shortname": ":art:",
@@ -7600,7 +7600,7 @@
     ]
   },
   "dart": {
-    "unicode": "1F3AF",
+    "unicode": "1f3af",
     "unicode_alternates": [],
     "name": "direct hit",
     "shortname": ":dart:",
@@ -7620,7 +7620,7 @@
     ]
   },
   "8ball": {
-    "unicode": "1F3B1",
+    "unicode": "1f3b1",
     "unicode_alternates": [],
     "name": "billiards",
     "shortname": ":8ball:",
@@ -7636,7 +7636,7 @@
     ]
   },
   "bowling": {
-    "unicode": "1F3B3",
+    "unicode": "1f3b3",
     "unicode_alternates": [],
     "name": "bowling",
     "shortname": ":bowling:",
@@ -7657,7 +7657,7 @@
     ]
   },
   "slot_machine": {
-    "unicode": "1F3B0",
+    "unicode": "1f3b0",
     "unicode_alternates": [],
     "name": "slot machine",
     "shortname": ":slot_machine:",
@@ -7675,7 +7675,7 @@
     ]
   },
   "game_die": {
-    "unicode": "1F3B2",
+    "unicode": "1f3b2",
     "unicode_alternates": [],
     "name": "game die",
     "shortname": ":game_die:",
@@ -7691,7 +7691,7 @@
     ]
   },
   "video_game": {
-    "unicode": "1F3AE",
+    "unicode": "1f3ae",
     "unicode_alternates": [],
     "name": "video game",
     "shortname": ":video_game:",
@@ -7710,7 +7710,7 @@
     ]
   },
   "flower_playing_cards": {
-    "unicode": "1F3B4",
+    "unicode": "1f3b4",
     "unicode_alternates": [],
     "name": "flower playing cards",
     "shortname": ":flower_playing_cards:",
@@ -7726,7 +7726,7 @@
     ]
   },
   "black_joker": {
-    "unicode": "1F0CF",
+    "unicode": "1f0cf",
     "unicode_alternates": [],
     "name": "playing card black joker",
     "shortname": ":black_joker:",
@@ -7741,7 +7741,7 @@
     ]
   },
   "mahjong": {
-    "unicode": "1F004",
+    "unicode": "1f004",
     "unicode_alternates": [
       "1F004-FE0F"
     ],
@@ -7758,7 +7758,7 @@
     ]
   },
   "carousel_horse": {
-    "unicode": "1F3A0",
+    "unicode": "1f3a0",
     "unicode_alternates": [],
     "name": "carousel horse",
     "shortname": ":carousel_horse:",
@@ -7776,7 +7776,7 @@
     ]
   },
   "ferris_wheel": {
-    "unicode": "1F3A1",
+    "unicode": "1f3a1",
     "unicode_alternates": [],
     "name": "ferris wheel",
     "shortname": ":ferris_wheel:",
@@ -7796,7 +7796,7 @@
     ]
   },
   "roller_coaster": {
-    "unicode": "1F3A2",
+    "unicode": "1f3a2",
     "unicode_alternates": [],
     "name": "roller coaster",
     "shortname": ":roller_coaster:",
@@ -7816,7 +7816,7 @@
     ]
   },
   "tomato": {
-    "unicode": "1F345",
+    "unicode": "1f345",
     "unicode_alternates": [],
     "name": "tomato",
     "shortname": ":tomato:",
@@ -7834,7 +7834,7 @@
     ]
   },
   "eggplant": {
-    "unicode": "1F346",
+    "unicode": "1f346",
     "unicode_alternates": [],
     "name": "aubergine",
     "shortname": ":eggplant:",
@@ -7852,7 +7852,7 @@
     ]
   },
   "corn": {
-    "unicode": "1F33D",
+    "unicode": "1f33d",
     "unicode_alternates": [],
     "name": "ear of maize",
     "shortname": ":corn:",
@@ -7875,7 +7875,7 @@
     ]
   },
   "sweet_potato": {
-    "unicode": "1F360",
+    "unicode": "1f360",
     "unicode_alternates": [],
     "name": "roasted sweet potato",
     "shortname": ":sweet_potato:",
@@ -7891,7 +7891,7 @@
     ]
   },
   "hot_pepper": {
-    "unicode": "1F336",
+    "unicode": "1f336",
     "unicode_alternates": [],
     "name": "hot pepper",
     "shortname": ":hot_pepper:",
@@ -7910,7 +7910,7 @@
     ]
   },
   "grapes": {
-    "unicode": "1F347",
+    "unicode": "1f347",
     "unicode_alternates": [],
     "name": "grapes",
     "shortname": ":grapes:",
@@ -7927,7 +7927,7 @@
     ]
   },
   "melon": {
-    "unicode": "1F348",
+    "unicode": "1f348",
     "unicode_alternates": [],
     "name": "melon",
     "shortname": ":melon:",
@@ -7944,7 +7944,7 @@
     ]
   },
   "watermelon": {
-    "unicode": "1F349",
+    "unicode": "1f349",
     "unicode_alternates": [],
     "name": "watermelon",
     "shortname": ":watermelon:",
@@ -7961,7 +7961,7 @@
     ]
   },
   "tangerine": {
-    "unicode": "1F34A",
+    "unicode": "1f34a",
     "unicode_alternates": [],
     "name": "tangerine",
     "shortname": ":tangerine:",
@@ -7978,7 +7978,7 @@
     ]
   },
   "lemon": {
-    "unicode": "1F34B",
+    "unicode": "1f34b",
     "unicode_alternates": [],
     "name": "lemon",
     "shortname": ":lemon:",
@@ -7994,7 +7994,7 @@
     ]
   },
   "banana": {
-    "unicode": "1F34C",
+    "unicode": "1f34c",
     "unicode_alternates": [],
     "name": "banana",
     "shortname": ":banana:",
@@ -8010,7 +8010,7 @@
     ]
   },
   "pineapple": {
-    "unicode": "1F34D",
+    "unicode": "1f34d",
     "unicode_alternates": [],
     "name": "pineapple",
     "shortname": ":pineapple:",
@@ -8028,7 +8028,7 @@
     ]
   },
   "apple": {
-    "unicode": "1F34E",
+    "unicode": "1f34e",
     "unicode_alternates": [],
     "name": "red apple",
     "shortname": ":apple:",
@@ -8048,7 +8048,7 @@
     ]
   },
   "green_apple": {
-    "unicode": "1F34F",
+    "unicode": "1f34f",
     "unicode_alternates": [],
     "name": "green apple",
     "shortname": ":green_apple:",
@@ -8067,7 +8067,7 @@
     ]
   },
   "pear": {
-    "unicode": "1F350",
+    "unicode": "1f350",
     "unicode_alternates": [],
     "name": "pear",
     "shortname": ":pear:",
@@ -8082,7 +8082,7 @@
     ]
   },
   "peach": {
-    "unicode": "1F351",
+    "unicode": "1f351",
     "unicode_alternates": [],
     "name": "peach",
     "shortname": ":peach:",
@@ -8099,7 +8099,7 @@
     ]
   },
   "cherries": {
-    "unicode": "1F352",
+    "unicode": "1f352",
     "unicode_alternates": [],
     "name": "cherries",
     "shortname": ":cherries:",
@@ -8116,7 +8116,7 @@
     ]
   },
   "strawberry": {
-    "unicode": "1F353",
+    "unicode": "1f353",
     "unicode_alternates": [],
     "name": "strawberry",
     "shortname": ":strawberry:",
@@ -8133,7 +8133,7 @@
     ]
   },
   "hamburger": {
-    "unicode": "1F354",
+    "unicode": "1f354",
     "unicode_alternates": [],
     "name": "hamburger",
     "shortname": ":hamburger:",
@@ -8151,7 +8151,7 @@
     ]
   },
   "pizza": {
-    "unicode": "1F355",
+    "unicode": "1f355",
     "unicode_alternates": [],
     "name": "slice of pizza",
     "shortname": ":pizza:",
@@ -8170,7 +8170,7 @@
     ]
   },
   "meat_on_bone": {
-    "unicode": "1F356",
+    "unicode": "1f356",
     "unicode_alternates": [],
     "name": "meat on bone",
     "shortname": ":meat_on_bone:",
@@ -8186,7 +8186,7 @@
     ]
   },
   "poultry_leg": {
-    "unicode": "1F357",
+    "unicode": "1f357",
     "unicode_alternates": [],
     "name": "poultry leg",
     "shortname": ":poultry_leg:",
@@ -8202,7 +8202,7 @@
     ]
   },
   "rice_cracker": {
-    "unicode": "1F358",
+    "unicode": "1f358",
     "unicode_alternates": [],
     "name": "rice cracker",
     "shortname": ":rice_cracker:",
@@ -8217,7 +8217,7 @@
     ]
   },
   "rice_ball": {
-    "unicode": "1F359",
+    "unicode": "1f359",
     "unicode_alternates": [],
     "name": "rice ball",
     "shortname": ":rice_ball:",
@@ -8234,7 +8234,7 @@
     ]
   },
   "rice": {
-    "unicode": "1F35A",
+    "unicode": "1f35a",
     "unicode_alternates": [],
     "name": "cooked rice",
     "shortname": ":rice:",
@@ -8250,7 +8250,7 @@
     ]
   },
   "curry": {
-    "unicode": "1F35B",
+    "unicode": "1f35b",
     "unicode_alternates": [],
     "name": "curry and rice",
     "shortname": ":curry:",
@@ -8269,7 +8269,7 @@
     ]
   },
   "ramen": {
-    "unicode": "1F35C",
+    "unicode": "1f35c",
     "unicode_alternates": [],
     "name": "steaming bowl",
     "shortname": ":ramen:",
@@ -8288,7 +8288,7 @@
     ]
   },
   "spaghetti": {
-    "unicode": "1F35D",
+    "unicode": "1f35d",
     "unicode_alternates": [],
     "name": "spaghetti",
     "shortname": ":spaghetti:",
@@ -8306,7 +8306,7 @@
     ]
   },
   "bread": {
-    "unicode": "1F35E",
+    "unicode": "1f35e",
     "unicode_alternates": [],
     "name": "bread",
     "shortname": ":bread:",
@@ -8323,7 +8323,7 @@
     ]
   },
   "fries": {
-    "unicode": "1F35F",
+    "unicode": "1f35f",
     "unicode_alternates": [],
     "name": "french fries",
     "shortname": ":fries:",
@@ -8341,7 +8341,7 @@
     ]
   },
   "dango": {
-    "unicode": "1F361",
+    "unicode": "1f361",
     "unicode_alternates": [],
     "name": "dango",
     "shortname": ":dango:",
@@ -8359,7 +8359,7 @@
     ]
   },
   "oden": {
-    "unicode": "1F362",
+    "unicode": "1f362",
     "unicode_alternates": [],
     "name": "oden",
     "shortname": ":oden:",
@@ -8376,7 +8376,7 @@
     ]
   },
   "sushi": {
-    "unicode": "1F363",
+    "unicode": "1f363",
     "unicode_alternates": [],
     "name": "sushi",
     "shortname": ":sushi:",
@@ -8393,7 +8393,7 @@
     ]
   },
   "fried_shrimp": {
-    "unicode": "1F364",
+    "unicode": "1f364",
     "unicode_alternates": [],
     "name": "fried shrimp",
     "shortname": ":fried_shrimp:",
@@ -8410,7 +8410,7 @@
     ]
   },
   "fish_cake": {
-    "unicode": "1F365",
+    "unicode": "1f365",
     "unicode_alternates": [],
     "name": "fish cake with swirl design",
     "shortname": ":fish_cake:",
@@ -8427,7 +8427,7 @@
     ]
   },
   "icecream": {
-    "unicode": "1F366",
+    "unicode": "1f366",
     "unicode_alternates": [],
     "name": "soft ice cream",
     "shortname": ":icecream:",
@@ -8448,7 +8448,7 @@
     ]
   },
   "shaved_ice": {
-    "unicode": "1F367",
+    "unicode": "1f367",
     "unicode_alternates": [],
     "name": "shaved ice",
     "shortname": ":shaved_ice:",
@@ -8465,7 +8465,7 @@
     ]
   },
   "ice_cream": {
-    "unicode": "1F368",
+    "unicode": "1f368",
     "unicode_alternates": [],
     "name": "ice cream",
     "shortname": ":ice_cream:",
@@ -8487,7 +8487,7 @@
     ]
   },
   "doughnut": {
-    "unicode": "1F369",
+    "unicode": "1f369",
     "unicode_alternates": [],
     "name": "doughnut",
     "shortname": ":doughnut:",
@@ -8511,7 +8511,7 @@
     ]
   },
   "cookie": {
-    "unicode": "1F36A",
+    "unicode": "1f36a",
     "unicode_alternates": [],
     "name": "cookie",
     "shortname": ":cookie:",
@@ -8531,7 +8531,7 @@
     ]
   },
   "chocolate_bar": {
-    "unicode": "1F36B",
+    "unicode": "1f36b",
     "unicode_alternates": [],
     "name": "chocolate bar",
     "shortname": ":chocolate_bar:",
@@ -8549,7 +8549,7 @@
     ]
   },
   "candy": {
-    "unicode": "1F36C",
+    "unicode": "1f36c",
     "unicode_alternates": [],
     "name": "candy",
     "shortname": ":candy:",
@@ -8566,7 +8566,7 @@
     ]
   },
   "lollipop": {
-    "unicode": "1F36D",
+    "unicode": "1f36d",
     "unicode_alternates": [],
     "name": "lollipop",
     "shortname": ":lollipop:",
@@ -8585,7 +8585,7 @@
     ]
   },
   "custard": {
-    "unicode": "1F36E",
+    "unicode": "1f36e",
     "unicode_alternates": [],
     "name": "custard",
     "shortname": ":custard:",
@@ -8606,7 +8606,7 @@
     ]
   },
   "honey_pot": {
-    "unicode": "1F36F",
+    "unicode": "1f36f",
     "unicode_alternates": [],
     "name": "honey pot",
     "shortname": ":honey_pot:",
@@ -8622,7 +8622,7 @@
     ]
   },
   "cake": {
-    "unicode": "1F370",
+    "unicode": "1f370",
     "unicode_alternates": [],
     "name": "shortcake",
     "shortname": ":cake:",
@@ -8640,7 +8640,7 @@
     ]
   },
   "bento": {
-    "unicode": "1F371",
+    "unicode": "1f371",
     "unicode_alternates": [],
     "name": "bento box",
     "shortname": ":bento:",
@@ -8659,7 +8659,7 @@
     ]
   },
   "stew": {
-    "unicode": "1F372",
+    "unicode": "1f372",
     "unicode_alternates": [],
     "name": "pot of food",
     "shortname": ":stew:",
@@ -8677,7 +8677,7 @@
     ]
   },
   "egg": {
-    "unicode": "1F373",
+    "unicode": "1f373",
     "unicode_alternates": [],
     "name": "cooking",
     "shortname": ":egg:",
@@ -8698,7 +8698,7 @@
     ]
   },
   "fork_and_knife": {
-    "unicode": "1F374",
+    "unicode": "1f374",
     "unicode_alternates": [],
     "name": "fork and knife",
     "shortname": ":fork_and_knife:",
@@ -8717,7 +8717,7 @@
     ]
   },
   "tea": {
-    "unicode": "1F375",
+    "unicode": "1f375",
     "unicode_alternates": [],
     "name": "teacup without handle",
     "shortname": ":tea:",
@@ -8757,7 +8757,7 @@
     ]
   },
   "sake": {
-    "unicode": "1F376",
+    "unicode": "1f376",
     "unicode_alternates": [],
     "name": "sake bottle and cup",
     "shortname": ":sake:",
@@ -8777,7 +8777,7 @@
     ]
   },
   "wine_glass": {
-    "unicode": "1F377",
+    "unicode": "1f377",
     "unicode_alternates": [],
     "name": "wine glass",
     "shortname": ":wine_glass:",
@@ -8799,7 +8799,7 @@
     ]
   },
   "cocktail": {
-    "unicode": "1F378",
+    "unicode": "1f378",
     "unicode_alternates": [],
     "name": "cocktail glass",
     "shortname": ":cocktail:",
@@ -8818,7 +8818,7 @@
     ]
   },
   "tropical_drink": {
-    "unicode": "1F379",
+    "unicode": "1f379",
     "unicode_alternates": [],
     "name": "tropical drink",
     "shortname": ":tropical_drink:",
@@ -8837,7 +8837,7 @@
     ]
   },
   "beer": {
-    "unicode": "1F37A",
+    "unicode": "1f37a",
     "unicode_alternates": [],
     "name": "beer mug",
     "shortname": ":beer:",
@@ -8865,7 +8865,7 @@
     ]
   },
   "beers": {
-    "unicode": "1F37B",
+    "unicode": "1f37b",
     "unicode_alternates": [],
     "name": "clinking beer mugs",
     "shortname": ":beers:",
@@ -8889,7 +8889,7 @@
     ]
   },
   "baby_bottle": {
-    "unicode": "1F37C",
+    "unicode": "1f37c",
     "unicode_alternates": [],
     "name": "baby bottle",
     "shortname": ":baby_bottle:",
@@ -8908,7 +8908,7 @@
     ]
   },
   "watch": {
-    "unicode": "231A",
+    "unicode": "231a",
     "unicode_alternates": [
       "231A-FE0F"
     ],
@@ -8925,7 +8925,7 @@
     ]
   },
   "iphone": {
-    "unicode": "1F4F1",
+    "unicode": "1f4f1",
     "unicode_alternates": [],
     "name": "mobile phone",
     "shortname": ":iphone:",
@@ -8944,7 +8944,7 @@
     ]
   },
   "calling": {
-    "unicode": "1F4F2",
+    "unicode": "1f4f2",
     "unicode_alternates": [],
     "name": "mobile phone with rightwards arrow at left",
     "shortname": ":calling:",
@@ -8959,7 +8959,7 @@
     ]
   },
   "computer": {
-    "unicode": "1F4BB",
+    "unicode": "1f4bb",
     "unicode_alternates": [],
     "name": "personal computer",
     "shortname": ":computer:",
@@ -8973,7 +8973,7 @@
     ]
   },
   "desktop": {
-    "unicode": "1F5A5",
+    "unicode": "1f5a5",
     "unicode_alternates": [],
     "name": "desktop computer",
     "shortname": ":desktop:",
@@ -8988,7 +8988,7 @@
     ]
   },
   "computer_old": {
-    "unicode": "1F5B3",
+    "unicode": "1f5b3",
     "unicode_alternates": [],
     "name": "old personal computer",
     "shortname": ":computer_old:",
@@ -9004,7 +9004,7 @@
     ]
   },
   "keyboard": {
-    "unicode": "1F5AE",
+    "unicode": "1f5ae",
     "unicode_alternates": [],
     "name": "wired keyboard",
     "shortname": ":keyboard:",
@@ -9022,7 +9022,7 @@
     ]
   },
   "mouse_one": {
-    "unicode": "1F5AF",
+    "unicode": "1f5af",
     "unicode_alternates": [],
     "name": "one button mouse",
     "shortname": ":mouse_one:",
@@ -9039,7 +9039,7 @@
     ]
   },
   "trackball": {
-    "unicode": "1F5B2",
+    "unicode": "1f5b2",
     "unicode_alternates": [],
     "name": "trackball",
     "shortname": ":trackball:",
@@ -9054,7 +9054,7 @@
     ]
   },
   "keyboard_mouse": {
-    "unicode": "1F5A6",
+    "unicode": "1f5a6",
     "unicode_alternates": [],
     "name": "keyboard and mouse",
     "shortname": ":keyboard_mouse:",
@@ -9071,7 +9071,7 @@
     ]
   },
   "network": {
-    "unicode": "1F5A7",
+    "unicode": "1f5a7",
     "unicode_alternates": [],
     "name": "three networked computers",
     "shortname": ":network:",
@@ -9089,7 +9089,7 @@
     ]
   },
   "printer": {
-    "unicode": "1F5A8",
+    "unicode": "1f5a8",
     "unicode_alternates": [],
     "name": "printer",
     "shortname": ":printer:",
@@ -9105,7 +9105,7 @@
     ]
   },
   "desktop_window": {
-    "unicode": "1F5D4",
+    "unicode": "1f5d4",
     "unicode_alternates": [],
     "name": "desktop window",
     "shortname": ":desktop_window:",
@@ -9118,7 +9118,7 @@
     ]
   },
   "calculator": {
-    "unicode": "1F5A9",
+    "unicode": "1f5a9",
     "unicode_alternates": [],
     "name": "pocket calculator",
     "shortname": ":calculator:",
@@ -9137,7 +9137,7 @@
     ]
   },
   "alarm_clock": {
-    "unicode": "23F0",
+    "unicode": "23f0",
     "unicode_alternates": [],
     "name": "alarm clock",
     "shortname": ":alarm_clock:",
@@ -9151,7 +9151,7 @@
     ]
   },
   "clock": {
-    "unicode": "1F570",
+    "unicode": "1f570",
     "unicode_alternates": [],
     "name": "mantlepiece clock",
     "shortname": ":clock:",
@@ -9166,7 +9166,7 @@
     ]
   },
   "hourglass_flowing_sand": {
-    "unicode": "23F3",
+    "unicode": "23f3",
     "unicode_alternates": [],
     "name": "hourglass with flowing sand",
     "shortname": ":hourglass_flowing_sand:",
@@ -9181,7 +9181,7 @@
     ]
   },
   "hourglass": {
-    "unicode": "231B",
+    "unicode": "231b",
     "unicode_alternates": [
       "231B-FE0F"
     ],
@@ -9198,7 +9198,7 @@
     ]
   },
   "camera": {
-    "unicode": "1F4F7",
+    "unicode": "1f4f7",
     "unicode_alternates": [],
     "name": "camera",
     "shortname": ":camera:",
@@ -9213,7 +9213,7 @@
     ]
   },
   "camera_with_flash": {
-    "unicode": "1F4F8",
+    "unicode": "1f4f8",
     "unicode_alternates": [],
     "name": "camera with flash",
     "shortname": ":camera_with_flash:",
@@ -9227,7 +9227,7 @@
     ]
   },
   "video_camera": {
-    "unicode": "1F4F9",
+    "unicode": "1f4f9",
     "unicode_alternates": [],
     "name": "video camera",
     "shortname": ":video_camera:",
@@ -9242,7 +9242,7 @@
     ]
   },
   "movie_camera": {
-    "unicode": "1F3A5",
+    "unicode": "1f3a5",
     "unicode_alternates": [],
     "name": "movie camera",
     "shortname": ":movie_camera:",
@@ -9259,7 +9259,7 @@
     ]
   },
   "projector": {
-    "unicode": "1F4FD",
+    "unicode": "1f4fd",
     "unicode_alternates": [],
     "name": "film projector",
     "shortname": ":projector:",
@@ -9279,7 +9279,7 @@
     ]
   },
   "tv": {
-    "unicode": "1F4FA",
+    "unicode": "1f4fa",
     "unicode_alternates": [],
     "name": "television",
     "shortname": ":tv:",
@@ -9296,7 +9296,7 @@
     ]
   },
   "keyboard_with_jacks": {
-    "unicode": "1F398",
+    "unicode": "1f398",
     "unicode_alternates": [],
     "name": "musical keyboard with jacks",
     "shortname": ":keyboard_with_jacks:",
@@ -9313,7 +9313,7 @@
     ]
   },
   "microphone2": {
-    "unicode": "1F399",
+    "unicode": "1f399",
     "unicode_alternates": [],
     "name": "studio microphone",
     "shortname": ":microphone2:",
@@ -9330,7 +9330,7 @@
     ]
   },
   "level_slider": {
-    "unicode": "1F39A",
+    "unicode": "1f39a",
     "unicode_alternates": [],
     "name": "level slider",
     "shortname": ":level_slider:",
@@ -9343,7 +9343,7 @@
     ]
   },
   "control_knobs": {
-    "unicode": "1F39B",
+    "unicode": "1f39b",
     "unicode_alternates": [],
     "name": "control knobs",
     "shortname": ":control_knobs:",
@@ -9356,7 +9356,7 @@
     ]
   },
   "radio": {
-    "unicode": "1F4FB",
+    "unicode": "1f4fb",
     "unicode_alternates": [],
     "name": "radio",
     "shortname": ":radio:",
@@ -9372,7 +9372,7 @@
     ]
   },
   "stereo": {
-    "unicode": "1F4FE",
+    "unicode": "1f4fe",
     "unicode_alternates": [],
     "name": "portable stereo",
     "shortname": ":stereo:",
@@ -9391,7 +9391,7 @@
     ]
   },
   "pager": {
-    "unicode": "1F4DF",
+    "unicode": "1f4df",
     "unicode_alternates": [],
     "name": "pager",
     "shortname": ":pager:",
@@ -9405,7 +9405,7 @@
     ]
   },
   "joystick": {
-    "unicode": "1F579",
+    "unicode": "1f579",
     "unicode_alternates": [],
     "name": "joystick",
     "shortname": ":joystick:",
@@ -9420,7 +9420,7 @@
     ]
   },
   "telephone_receiver": {
-    "unicode": "1F4DE",
+    "unicode": "1f4de",
     "unicode_alternates": [],
     "name": "telephone receiver",
     "shortname": ":telephone_receiver:",
@@ -9436,7 +9436,7 @@
     ]
   },
   "left_receiver": {
-    "unicode": "1F57B",
+    "unicode": "1f57b",
     "unicode_alternates": [],
     "name": "left hand telephone receiver",
     "shortname": ":left_receiver:",
@@ -9453,7 +9453,7 @@
     ]
   },
   "telephone": {
-    "unicode": "260E",
+    "unicode": "260e",
     "unicode_alternates": [
       "260E-FE0F"
     ],
@@ -9471,7 +9471,7 @@
     ]
   },
   "telephone_white": {
-    "unicode": "1F57E",
+    "unicode": "1f57e",
     "unicode_alternates": [],
     "name": "white touchtone telephone",
     "shortname": ":telephone_white:",
@@ -9488,7 +9488,7 @@
     ]
   },
   "telephone_black": {
-    "unicode": "1F57F",
+    "unicode": "1f57f",
     "unicode_alternates": [],
     "name": "black touchtone telephone",
     "shortname": ":telephone_black:",
@@ -9505,7 +9505,7 @@
     ]
   },
   "flip_phone": {
-    "unicode": "1F581",
+    "unicode": "1f581",
     "unicode_alternates": [],
     "name": "clamshell mobile phone",
     "shortname": ":flip_phone:",
@@ -9520,7 +9520,7 @@
     ]
   },
   "fax": {
-    "unicode": "1F4E0",
+    "unicode": "1f4e0",
     "unicode_alternates": [],
     "name": "fax machine",
     "shortname": ":fax:",
@@ -9534,7 +9534,7 @@
     ]
   },
   "minidisc": {
-    "unicode": "1F4BD",
+    "unicode": "1f4bd",
     "unicode_alternates": [],
     "name": "minidisc",
     "shortname": ":minidisc:",
@@ -9551,7 +9551,7 @@
     ]
   },
   "floppy_disk": {
-    "unicode": "1F4BE",
+    "unicode": "1f4be",
     "unicode_alternates": [],
     "name": "floppy disk",
     "shortname": ":floppy_disk:",
@@ -9571,7 +9571,7 @@
     ]
   },
   "floppy_black": {
-    "unicode": "1F5AA",
+    "unicode": "1f5aa",
     "unicode_alternates": [],
     "name": "black hard shell floppy disk",
     "shortname": ":floppy_black:",
@@ -9593,7 +9593,7 @@
     ]
   },
   "floppy_white": {
-    "unicode": "1F5AB",
+    "unicode": "1f5ab",
     "unicode_alternates": [],
     "name": "white hard shell floppy disk",
     "shortname": ":floppy_white:",
@@ -9615,7 +9615,7 @@
     ]
   },
   "cartridge": {
-    "unicode": "1F5AD",
+    "unicode": "1f5ad",
     "unicode_alternates": [],
     "name": "tape cartridge",
     "shortname": ":cartridge:",
@@ -9638,7 +9638,7 @@
     ]
   },
   "hard_disk": {
-    "unicode": "1F5B4",
+    "unicode": "1f5b4",
     "unicode_alternates": [],
     "name": "hard disk",
     "shortname": ":hard_disk:",
@@ -9659,7 +9659,7 @@
     ]
   },
   "cd": {
-    "unicode": "1F4BF",
+    "unicode": "1f4bf",
     "unicode_alternates": [],
     "name": "optical disc",
     "shortname": ":cd:",
@@ -9675,7 +9675,7 @@
     ]
   },
   "dvd": {
-    "unicode": "1F4C0",
+    "unicode": "1f4c0",
     "unicode_alternates": [],
     "name": "dvd",
     "shortname": ":dvd:",
@@ -9691,7 +9691,7 @@
     ]
   },
   "optical_disk": {
-    "unicode": "1F5B8",
+    "unicode": "1f5b8",
     "unicode_alternates": [],
     "name": "optical disc icon",
     "shortname": ":optical_disk:",
@@ -9710,7 +9710,7 @@
     ]
   },
   "vhs": {
-    "unicode": "1F4FC",
+    "unicode": "1f4fc",
     "unicode_alternates": [],
     "name": "videocassette",
     "shortname": ":vhs:",
@@ -9725,7 +9725,7 @@
     ]
   },
   "battery": {
-    "unicode": "1F50B",
+    "unicode": "1f50b",
     "unicode_alternates": [],
     "name": "battery",
     "shortname": ":battery:",
@@ -9740,7 +9740,7 @@
     ]
   },
   "electric_plug": {
-    "unicode": "1F50C",
+    "unicode": "1f50c",
     "unicode_alternates": [],
     "name": "electric plug",
     "shortname": ":electric_plug:",
@@ -9754,7 +9754,7 @@
     ]
   },
   "bulb": {
-    "unicode": "1F4A1",
+    "unicode": "1f4a1",
     "unicode_alternates": [],
     "name": "electric light bulb",
     "shortname": ":bulb:",
@@ -9768,7 +9768,7 @@
     ]
   },
   "flashlight": {
-    "unicode": "1F526",
+    "unicode": "1f526",
     "unicode_alternates": [],
     "name": "electric torch",
     "shortname": ":flashlight:",
@@ -9782,7 +9782,7 @@
     ]
   },
   "candle": {
-    "unicode": "1F56F",
+    "unicode": "1f56f",
     "unicode_alternates": [],
     "name": "candle",
     "shortname": ":candle:",
@@ -9796,7 +9796,7 @@
     ]
   },
   "satellite": {
-    "unicode": "1F4E1",
+    "unicode": "1f4e1",
     "unicode_alternates": [],
     "name": "satellite antenna",
     "shortname": ":satellite:",
@@ -9809,7 +9809,7 @@
     ]
   },
   "satellite_orbital": {
-    "unicode": "1F6F0",
+    "unicode": "1f6f0",
     "unicode_alternates": [],
     "name": "satellite",
     "shortname": ":satellite_orbital:",
@@ -9824,7 +9824,7 @@
     ]
   },
   "credit_card": {
-    "unicode": "1F4B3",
+    "unicode": "1f4b3",
     "unicode_alternates": [],
     "name": "credit card",
     "shortname": ":credit_card:",
@@ -9849,7 +9849,7 @@
     ]
   },
   "money_with_wings": {
-    "unicode": "1F4B8",
+    "unicode": "1f4b8",
     "unicode_alternates": [],
     "name": "money with wings",
     "shortname": ":money_with_wings:",
@@ -9872,7 +9872,7 @@
     ]
   },
   "moneybag": {
-    "unicode": "1F4B0",
+    "unicode": "1f4b0",
     "unicode_alternates": [],
     "name": "money bag",
     "shortname": ":moneybag:",
@@ -9889,7 +9889,7 @@
     ]
   },
   "gem": {
-    "unicode": "1F48E",
+    "unicode": "1f48e",
     "unicode_alternates": [],
     "name": "gem stone",
     "shortname": ":gem:",
@@ -9904,7 +9904,7 @@
     ]
   },
   "closed_umbrella": {
-    "unicode": "1F302",
+    "unicode": "1f302",
     "unicode_alternates": [],
     "name": "closed umbrella",
     "shortname": ":closed_umbrella:",
@@ -9924,7 +9924,7 @@
     ]
   },
   "pouch": {
-    "unicode": "1F45D",
+    "unicode": "1f45d",
     "unicode_alternates": [],
     "name": "pouch",
     "shortname": ":pouch:",
@@ -9942,7 +9942,7 @@
     ]
   },
   "purse": {
-    "unicode": "1F45B",
+    "unicode": "1f45b",
     "unicode_alternates": [],
     "name": "purse",
     "shortname": ":purse:",
@@ -9964,7 +9964,7 @@
     ]
   },
   "handbag": {
-    "unicode": "1F45C",
+    "unicode": "1f45c",
     "unicode_alternates": [],
     "name": "handbag",
     "shortname": ":handbag:",
@@ -9980,7 +9980,7 @@
     ]
   },
   "briefcase": {
-    "unicode": "1F4BC",
+    "unicode": "1f4bc",
     "unicode_alternates": [],
     "name": "briefcase",
     "shortname": ":briefcase:",
@@ -9995,7 +9995,7 @@
     ]
   },
   "school_satchel": {
-    "unicode": "1F392",
+    "unicode": "1f392",
     "unicode_alternates": [],
     "name": "school satchel",
     "shortname": ":school_satchel:",
@@ -10018,7 +10018,7 @@
     ]
   },
   "lipstick": {
-    "unicode": "1F484",
+    "unicode": "1f484",
     "unicode_alternates": [],
     "name": "lipstick",
     "shortname": ":lipstick:",
@@ -10033,7 +10033,7 @@
     ]
   },
   "eyeglasses": {
-    "unicode": "1F453",
+    "unicode": "1f453",
     "unicode_alternates": [],
     "name": "eyeglasses",
     "shortname": ":eyeglasses:",
@@ -10060,7 +10060,7 @@
     ]
   },
   "dark_sunglasses": {
-    "unicode": "1F576",
+    "unicode": "1f576",
     "unicode_alternates": [],
     "name": "dark sunglasses",
     "shortname": ":dark_sunglasses:",
@@ -10074,7 +10074,7 @@
     ]
   },
   "womans_hat": {
-    "unicode": "1F452",
+    "unicode": "1f452",
     "unicode_alternates": [],
     "name": "womans hat",
     "shortname": ":womans_hat:",
@@ -10089,7 +10089,7 @@
     ]
   },
   "sandal": {
-    "unicode": "1F461",
+    "unicode": "1f461",
     "unicode_alternates": [],
     "name": "womans sandal",
     "shortname": ":sandal:",
@@ -10104,7 +10104,7 @@
     ]
   },
   "high_heel": {
-    "unicode": "1F460",
+    "unicode": "1f460",
     "unicode_alternates": [],
     "name": "high-heeled shoe",
     "shortname": ":high_heel:",
@@ -10119,7 +10119,7 @@
     ]
   },
   "boot": {
-    "unicode": "1F462",
+    "unicode": "1f462",
     "unicode_alternates": [],
     "name": "womans boots",
     "shortname": ":boot:",
@@ -10133,7 +10133,7 @@
     ]
   },
   "mans_shoe": {
-    "unicode": "1F45E",
+    "unicode": "1f45e",
     "unicode_alternates": [],
     "name": "mans shoe",
     "shortname": ":mans_shoe:",
@@ -10147,7 +10147,7 @@
     ]
   },
   "athletic_shoe": {
-    "unicode": "1F45F",
+    "unicode": "1f45f",
     "unicode_alternates": [],
     "name": "athletic shoe",
     "shortname": ":athletic_shoe:",
@@ -10161,7 +10161,7 @@
     ]
   },
   "bikini": {
-    "unicode": "1F459",
+    "unicode": "1f459",
     "unicode_alternates": [],
     "name": "bikini",
     "shortname": ":bikini:",
@@ -10179,7 +10179,7 @@
     ]
   },
   "dress": {
-    "unicode": "1F457",
+    "unicode": "1f457",
     "unicode_alternates": [],
     "name": "dress",
     "shortname": ":dress:",
@@ -10193,7 +10193,7 @@
     ]
   },
   "kimono": {
-    "unicode": "1F458",
+    "unicode": "1f458",
     "unicode_alternates": [],
     "name": "kimono",
     "shortname": ":kimono:",
@@ -10210,7 +10210,7 @@
     ]
   },
   "womans_clothes": {
-    "unicode": "1F45A",
+    "unicode": "1f45a",
     "unicode_alternates": [],
     "name": "womans clothes",
     "shortname": ":womans_clothes:",
@@ -10233,7 +10233,7 @@
     ]
   },
   "shirt": {
-    "unicode": "1F455",
+    "unicode": "1f455",
     "unicode_alternates": [],
     "name": "t-shirt",
     "shortname": ":shirt:",
@@ -10249,7 +10249,7 @@
     ]
   },
   "necktie": {
-    "unicode": "1F454",
+    "unicode": "1f454",
     "unicode_alternates": [],
     "name": "necktie",
     "shortname": ":necktie:",
@@ -10266,7 +10266,7 @@
     ]
   },
   "jeans": {
-    "unicode": "1F456",
+    "unicode": "1f456",
     "unicode_alternates": [],
     "name": "jeans",
     "shortname": ":jeans:",
@@ -10288,7 +10288,7 @@
     ]
   },
   "door": {
-    "unicode": "1F6AA",
+    "unicode": "1f6aa",
     "unicode_alternates": [],
     "name": "door",
     "shortname": ":door:",
@@ -10308,7 +10308,7 @@
     ]
   },
   "shower": {
-    "unicode": "1F6BF",
+    "unicode": "1f6bf",
     "unicode_alternates": [],
     "name": "shower",
     "shortname": ":shower:",
@@ -10328,7 +10328,7 @@
     ]
   },
   "bathtub": {
-    "unicode": "1F6C1",
+    "unicode": "1f6c1",
     "unicode_alternates": [],
     "name": "bathtub",
     "shortname": ":bathtub:",
@@ -10353,7 +10353,7 @@
     ]
   },
   "toilet": {
-    "unicode": "1F6BD",
+    "unicode": "1f6bd",
     "unicode_alternates": [],
     "name": "toilet",
     "shortname": ":toilet:",
@@ -10373,7 +10373,7 @@
     ]
   },
   "barber": {
-    "unicode": "1F488",
+    "unicode": "1f488",
     "unicode_alternates": [],
     "name": "barber pole",
     "shortname": ":barber:",
@@ -10389,7 +10389,7 @@
     ]
   },
   "syringe": {
-    "unicode": "1F489",
+    "unicode": "1f489",
     "unicode_alternates": [],
     "name": "syringe",
     "shortname": ":syringe:",
@@ -10407,7 +10407,7 @@
     ]
   },
   "pill": {
-    "unicode": "1F48A",
+    "unicode": "1f48a",
     "unicode_alternates": [],
     "name": "pill",
     "shortname": ":pill:",
@@ -10423,7 +10423,7 @@
     ]
   },
   "microscope": {
-    "unicode": "1F52C",
+    "unicode": "1f52c",
     "unicode_alternates": [],
     "name": "microscope",
     "shortname": ":microscope:",
@@ -10438,7 +10438,7 @@
     ]
   },
   "telescope": {
-    "unicode": "1F52D",
+    "unicode": "1f52d",
     "unicode_alternates": [],
     "name": "telescope",
     "shortname": ":telescope:",
@@ -10452,7 +10452,7 @@
     ]
   },
   "crystal_ball": {
-    "unicode": "1F52E",
+    "unicode": "1f52e",
     "unicode_alternates": [],
     "name": "crystal ball",
     "shortname": ":crystal_ball:",
@@ -10467,7 +10467,7 @@
     ]
   },
   "wrench": {
-    "unicode": "1F527",
+    "unicode": "1f527",
     "unicode_alternates": [],
     "name": "wrench",
     "shortname": ":wrench:",
@@ -10482,7 +10482,7 @@
     ]
   },
   "knife": {
-    "unicode": "1F52A",
+    "unicode": "1f52a",
     "unicode_alternates": [],
     "name": "hocho",
     "shortname": ":knife:",
@@ -10495,7 +10495,7 @@
     ]
   },
   "dagger": {
-    "unicode": "1F5E1",
+    "unicode": "1f5e1",
     "unicode_alternates": [],
     "name": "dagger knife",
     "shortname": ":dagger:",
@@ -10511,7 +10511,7 @@
     ]
   },
   "nut_and_bolt": {
-    "unicode": "1F529",
+    "unicode": "1f529",
     "unicode_alternates": [],
     "name": "nut and bolt",
     "shortname": ":nut_and_bolt:",
@@ -10524,7 +10524,7 @@
     ]
   },
   "hammer": {
-    "unicode": "1F528",
+    "unicode": "1f528",
     "unicode_alternates": [],
     "name": "hammer",
     "shortname": ":hammer:",
@@ -10542,7 +10542,7 @@
     ]
   },
   "tools": {
-    "unicode": "1F6E0",
+    "unicode": "1f6e0",
     "unicode_alternates": [],
     "name": "hammer and wrench",
     "shortname": ":tools:",
@@ -10557,7 +10557,7 @@
     ]
   },
   "oil": {
-    "unicode": "1F6E2",
+    "unicode": "1f6e2",
     "unicode_alternates": [],
     "name": "oil drum",
     "shortname": ":oil:",
@@ -10572,7 +10572,7 @@
     ]
   },
   "bomb": {
-    "unicode": "1F4A3",
+    "unicode": "1f4a3",
     "unicode_alternates": [],
     "name": "bomb",
     "shortname": ":bomb:",
@@ -10586,7 +10586,7 @@
     ]
   },
   "smoking": {
-    "unicode": "1F6AC",
+    "unicode": "1f6ac",
     "unicode_alternates": [],
     "name": "smoking symbol",
     "shortname": ":smoking:",
@@ -10607,7 +10607,7 @@
     ]
   },
   "crossbones": {
-    "unicode": "1F571",
+    "unicode": "1f571",
     "unicode_alternates": [],
     "name": "black skull and crossbones",
     "shortname": ":crossbones:",
@@ -10624,7 +10624,7 @@
     ]
   },
   "gun": {
-    "unicode": "1F52B",
+    "unicode": "1f52b",
     "unicode_alternates": [],
     "name": "pistol",
     "shortname": ":gun:",
@@ -10639,7 +10639,7 @@
     ]
   },
   "bookmark": {
-    "unicode": "1F516",
+    "unicode": "1f516",
     "unicode_alternates": [],
     "name": "bookmark",
     "shortname": ":bookmark:",
@@ -10652,7 +10652,7 @@
     ]
   },
   "newspaper": {
-    "unicode": "1F4F0",
+    "unicode": "1f4f0",
     "unicode_alternates": [],
     "name": "newspaper",
     "shortname": ":newspaper:",
@@ -10666,7 +10666,7 @@
     ]
   },
   "newspaper2": {
-    "unicode": "1F5DE",
+    "unicode": "1f5de",
     "unicode_alternates": [],
     "name": "rolled-up newspaper",
     "shortname": ":newspaper2:",
@@ -10682,7 +10682,7 @@
     ]
   },
   "thermometer": {
-    "unicode": "1F321",
+    "unicode": "1f321",
     "unicode_alternates": [],
     "name": "thermometer",
     "shortname": ":thermometer:",
@@ -10695,7 +10695,7 @@
     ]
   },
   "label": {
-    "unicode": "1F3F7",
+    "unicode": "1f3f7",
     "unicode_alternates": [],
     "name": "label",
     "shortname": ":label:",
@@ -10708,7 +10708,7 @@
     ]
   },
   "key": {
-    "unicode": "1F511",
+    "unicode": "1f511",
     "unicode_alternates": [],
     "name": "key",
     "shortname": ":key:",
@@ -10723,7 +10723,7 @@
     ]
   },
   "key2": {
-    "unicode": "1F5DD",
+    "unicode": "1f5dd",
     "unicode_alternates": [],
     "name": "old key",
     "shortname": ":key2:",
@@ -10759,7 +10759,7 @@
     ]
   },
   "envelope_back": {
-    "unicode": "1F582",
+    "unicode": "1f582",
     "unicode_alternates": [],
     "name": "back of envelope",
     "shortname": ":envelope_back:",
@@ -10777,7 +10777,7 @@
     ]
   },
   "envelope_stamped": {
-    "unicode": "1F583",
+    "unicode": "1f583",
     "unicode_alternates": [],
     "name": "stamped envelope",
     "shortname": ":envelope_stamped:",
@@ -10795,7 +10795,7 @@
     ]
   },
   "envelope_flying": {
-    "unicode": "1F585",
+    "unicode": "1f585",
     "unicode_alternates": [],
     "name": "flying envelope",
     "shortname": ":envelope_flying:",
@@ -10813,7 +10813,7 @@
     ]
   },
   "envelope_stamped_pen": {
-    "unicode": "1F586",
+    "unicode": "1f586",
     "unicode_alternates": [],
     "name": "pen over stamped envelope",
     "shortname": ":envelope_stamped_pen:",
@@ -10831,7 +10831,7 @@
     ]
   },
   "envelope_with_arrow": {
-    "unicode": "1F4E9",
+    "unicode": "1f4e9",
     "unicode_alternates": [],
     "name": "envelope with downwards arrow above",
     "shortname": ":envelope_with_arrow:",
@@ -10844,7 +10844,7 @@
     ]
   },
   "incoming_envelope": {
-    "unicode": "1F4E8",
+    "unicode": "1f4e8",
     "unicode_alternates": [],
     "name": "incoming envelope",
     "shortname": ":incoming_envelope:",
@@ -10858,7 +10858,7 @@
     ]
   },
   "e-mail": {
-    "unicode": "1F4E7",
+    "unicode": "1f4e7",
     "unicode_alternates": [],
     "name": "e-mail symbol",
     "shortname": ":e-mail:",
@@ -10875,7 +10875,7 @@
     ]
   },
   "inbox_tray": {
-    "unicode": "1F4E5",
+    "unicode": "1f4e5",
     "unicode_alternates": [],
     "name": "inbox tray",
     "shortname": ":inbox_tray:",
@@ -10889,7 +10889,7 @@
     ]
   },
   "outbox_tray": {
-    "unicode": "1F4E4",
+    "unicode": "1f4e4",
     "unicode_alternates": [],
     "name": "outbox tray",
     "shortname": ":outbox_tray:",
@@ -10903,7 +10903,7 @@
     ]
   },
   "package": {
-    "unicode": "1F4E6",
+    "unicode": "1f4e6",
     "unicode_alternates": [],
     "name": "package",
     "shortname": ":package:",
@@ -10917,7 +10917,7 @@
     ]
   },
   "postal_horn": {
-    "unicode": "1F4EF",
+    "unicode": "1f4ef",
     "unicode_alternates": [],
     "name": "postal horn",
     "shortname": ":postal_horn:",
@@ -10931,7 +10931,7 @@
     ]
   },
   "postbox": {
-    "unicode": "1F4EE",
+    "unicode": "1f4ee",
     "unicode_alternates": [],
     "name": "postbox",
     "shortname": ":postbox:",
@@ -10946,7 +10946,7 @@
     ]
   },
   "mailbox_closed": {
-    "unicode": "1F4EA",
+    "unicode": "1f4ea",
     "unicode_alternates": [],
     "name": "closed mailbox with lowered flag",
     "shortname": ":mailbox_closed:",
@@ -10961,7 +10961,7 @@
     ]
   },
   "mailbox": {
-    "unicode": "1F4EB",
+    "unicode": "1f4eb",
     "unicode_alternates": [],
     "name": "closed mailbox with raised flag",
     "shortname": ":mailbox:",
@@ -10976,7 +10976,7 @@
     ]
   },
   "mailbox_with_no_mail": {
-    "unicode": "1F4ED",
+    "unicode": "1f4ed",
     "unicode_alternates": [],
     "name": "open mailbox with lowered flag",
     "shortname": ":mailbox_with_no_mail:",
@@ -10990,7 +10990,7 @@
     ]
   },
   "mailbox_with_mail": {
-    "unicode": "1F4EC",
+    "unicode": "1f4ec",
     "unicode_alternates": [],
     "name": "open mailbox with raised flag",
     "shortname": ":mailbox_with_mail:",
@@ -11005,7 +11005,7 @@
     ]
   },
   "document": {
-    "unicode": "1F5CE",
+    "unicode": "1f5ce",
     "unicode_alternates": [],
     "name": "document",
     "shortname": ":document:",
@@ -11018,7 +11018,7 @@
     ]
   },
   "document_text": {
-    "unicode": "1F5B9",
+    "unicode": "1f5b9",
     "unicode_alternates": [],
     "name": "document with text",
     "shortname": ":document_text:",
@@ -11033,7 +11033,7 @@
     ]
   },
   "page": {
-    "unicode": "1F5CF",
+    "unicode": "1f5cf",
     "unicode_alternates": [],
     "name": "page",
     "shortname": ":page:",
@@ -11046,7 +11046,7 @@
     ]
   },
   "page_facing_up": {
-    "unicode": "1F4C4",
+    "unicode": "1f4c4",
     "unicode_alternates": [],
     "name": "page facing up",
     "shortname": ":page_facing_up:",
@@ -11059,7 +11059,7 @@
     ]
   },
   "page_with_curl": {
-    "unicode": "1F4C3",
+    "unicode": "1f4c3",
     "unicode_alternates": [],
     "name": "page with curl",
     "shortname": ":page_with_curl:",
@@ -11072,7 +11072,7 @@
     ]
   },
   "pages": {
-    "unicode": "1F5D0",
+    "unicode": "1f5d0",
     "unicode_alternates": [],
     "name": "pages",
     "shortname": ":pages:",
@@ -11085,7 +11085,7 @@
     ]
   },
   "bookmark_tabs": {
-    "unicode": "1F4D1",
+    "unicode": "1f4d1",
     "unicode_alternates": [],
     "name": "bookmark tabs",
     "shortname": ":bookmark_tabs:",
@@ -11098,7 +11098,7 @@
     ]
   },
   "wastebasket": {
-    "unicode": "1F5D1",
+    "unicode": "1f5d1",
     "unicode_alternates": [],
     "name": "wastebasket",
     "shortname": ":wastebasket:",
@@ -11113,7 +11113,7 @@
     ]
   },
   "note_empty": {
-    "unicode": "1F5C6",
+    "unicode": "1f5c6",
     "unicode_alternates": [],
     "name": "empty note page",
     "shortname": ":note_empty:",
@@ -11129,7 +11129,7 @@
     ]
   },
   "notepad_empty": {
-    "unicode": "1F5C7",
+    "unicode": "1f5c7",
     "unicode_alternates": [],
     "name": "empty note pad",
     "shortname": ":notepad_empty:",
@@ -11145,7 +11145,7 @@
     ]
   },
   "note": {
-    "unicode": "1F5C9",
+    "unicode": "1f5c9",
     "unicode_alternates": [],
     "name": "note page",
     "shortname": ":note:",
@@ -11161,7 +11161,7 @@
     ]
   },
   "notepad": {
-    "unicode": "1F5CA",
+    "unicode": "1f5ca",
     "unicode_alternates": [],
     "name": "note pad",
     "shortname": ":notepad:",
@@ -11177,7 +11177,7 @@
     ]
   },
   "notepad_spiral": {
-    "unicode": "1F5D2",
+    "unicode": "1f5d2",
     "unicode_alternates": [],
     "name": "spiral note pad",
     "shortname": ":notepad_spiral:",
@@ -11192,7 +11192,7 @@
     ]
   },
   "chart_with_upwards_trend": {
-    "unicode": "1F4C8",
+    "unicode": "1f4c8",
     "unicode_alternates": [],
     "name": "chart with upwards trend",
     "shortname": ":chart_with_upwards_trend:",
@@ -11206,7 +11206,7 @@
     ]
   },
   "chart_with_downwards_trend": {
-    "unicode": "1F4C9",
+    "unicode": "1f4c9",
     "unicode_alternates": [],
     "name": "chart with downwards trend",
     "shortname": ":chart_with_downwards_trend:",
@@ -11220,7 +11220,7 @@
     ]
   },
   "bar_chart": {
-    "unicode": "1F4CA",
+    "unicode": "1f4ca",
     "unicode_alternates": [],
     "name": "bar chart",
     "shortname": ":bar_chart:",
@@ -11235,7 +11235,7 @@
     ]
   },
   "stock_chart": {
-    "unicode": "1F5E0",
+    "unicode": "1f5e0",
     "unicode_alternates": [],
     "name": "stock chart",
     "shortname": ":stock_chart:",
@@ -11251,7 +11251,7 @@
     ]
   },
   "date": {
-    "unicode": "1F4C5",
+    "unicode": "1f4c5",
     "unicode_alternates": [],
     "name": "calendar",
     "shortname": ":date:",
@@ -11266,7 +11266,7 @@
     ]
   },
   "calendar": {
-    "unicode": "1F4C6",
+    "unicode": "1f4c6",
     "unicode_alternates": [],
     "name": "tear-off calendar",
     "shortname": ":calendar:",
@@ -11281,7 +11281,7 @@
     ]
   },
   "calendar_spiral": {
-    "unicode": "1F5D3",
+    "unicode": "1f5d3",
     "unicode_alternates": [],
     "name": "spiral calendar pad",
     "shortname": ":calendar_spiral:",
@@ -11298,7 +11298,7 @@
     ]
   },
   "ballot_box": {
-    "unicode": "1F5F3",
+    "unicode": "1f5f3",
     "unicode_alternates": [],
     "name": "ballot box with ballot",
     "shortname": ":ballot_box:",
@@ -11313,7 +11313,7 @@
     ]
   },
   "low_brightness": {
-    "unicode": "1F505",
+    "unicode": "1f505",
     "unicode_alternates": [],
     "name": "low brightness symbol",
     "shortname": ":low_brightness:",
@@ -11327,7 +11327,7 @@
     ]
   },
   "high_brightness": {
-    "unicode": "1F506",
+    "unicode": "1f506",
     "unicode_alternates": [],
     "name": "high brightness symbol",
     "shortname": ":high_brightness:",
@@ -11342,7 +11342,7 @@
     ]
   },
   "compression": {
-    "unicode": "1F5DC",
+    "unicode": "1f5dc",
     "unicode_alternates": [],
     "name": "compression",
     "shortname": ":compression:",
@@ -11355,7 +11355,7 @@
     ]
   },
   "frame_x": {
-    "unicode": "1F5BE",
+    "unicode": "1f5be",
     "unicode_alternates": [],
     "name": "frame with an x",
     "shortname": ":frame_x:",
@@ -11371,7 +11371,7 @@
     ]
   },
   "frame_photo": {
-    "unicode": "1F5BC",
+    "unicode": "1f5bc",
     "unicode_alternates": [],
     "name": "frame with picture",
     "shortname": ":frame_photo:",
@@ -11386,7 +11386,7 @@
     ]
   },
   "frame_tiles": {
-    "unicode": "1F5BD",
+    "unicode": "1f5bd",
     "unicode_alternates": [],
     "name": "frame with tiles",
     "shortname": ":frame_tiles:",
@@ -11402,7 +11402,7 @@
     ]
   },
   "scroll": {
-    "unicode": "1F4DC",
+    "unicode": "1f4dc",
     "unicode_alternates": [],
     "name": "scroll",
     "shortname": ":scroll:",
@@ -11420,7 +11420,7 @@
     ]
   },
   "clipboard": {
-    "unicode": "1F4CB",
+    "unicode": "1f4cb",
     "unicode_alternates": [],
     "name": "clipboard",
     "shortname": ":clipboard:",
@@ -11434,7 +11434,7 @@
     ]
   },
   "book2": {
-    "unicode": "1F56E",
+    "unicode": "1f56e",
     "unicode_alternates": [],
     "name": "book",
     "shortname": ":book2:",
@@ -11451,7 +11451,7 @@
     ]
   },
   "book": {
-    "unicode": "1F4D6",
+    "unicode": "1f4d6",
     "unicode_alternates": [],
     "name": "open book",
     "shortname": ":book:",
@@ -11468,7 +11468,7 @@
     ]
   },
   "notebook": {
-    "unicode": "1F4D3",
+    "unicode": "1f4d3",
     "unicode_alternates": [],
     "name": "notebook",
     "shortname": ":notebook:",
@@ -11485,7 +11485,7 @@
     ]
   },
   "notebook_with_decorative_cover": {
-    "unicode": "1F4D4",
+    "unicode": "1f4d4",
     "unicode_alternates": [],
     "name": "notebook with decorative cover",
     "shortname": ":notebook_with_decorative_cover:",
@@ -11502,7 +11502,7 @@
     ]
   },
   "ledger": {
-    "unicode": "1F4D2",
+    "unicode": "1f4d2",
     "unicode_alternates": [],
     "name": "ledger",
     "shortname": ":ledger:",
@@ -11519,7 +11519,7 @@
     ]
   },
   "closed_book": {
-    "unicode": "1F4D5",
+    "unicode": "1f4d5",
     "unicode_alternates": [],
     "name": "closed book",
     "shortname": ":closed_book:",
@@ -11535,7 +11535,7 @@
     ]
   },
   "green_book": {
-    "unicode": "1F4D7",
+    "unicode": "1f4d7",
     "unicode_alternates": [],
     "name": "green book",
     "shortname": ":green_book:",
@@ -11551,7 +11551,7 @@
     ]
   },
   "blue_book": {
-    "unicode": "1F4D8",
+    "unicode": "1f4d8",
     "unicode_alternates": [],
     "name": "blue book",
     "shortname": ":blue_book:",
@@ -11567,7 +11567,7 @@
     ]
   },
   "orange_book": {
-    "unicode": "1F4D9",
+    "unicode": "1f4d9",
     "unicode_alternates": [],
     "name": "orange book",
     "shortname": ":orange_book:",
@@ -11583,7 +11583,7 @@
     ]
   },
   "books": {
-    "unicode": "1F4DA",
+    "unicode": "1f4da",
     "unicode_alternates": [],
     "name": "books",
     "shortname": ":books:",
@@ -11601,7 +11601,7 @@
     ]
   },
   "card_index": {
-    "unicode": "1F4C7",
+    "unicode": "1f4c7",
     "unicode_alternates": [],
     "name": "card index",
     "shortname": ":card_index:",
@@ -11616,7 +11616,7 @@
     ]
   },
   "dividers": {
-    "unicode": "1F5C2",
+    "unicode": "1f5c2",
     "unicode_alternates": [],
     "name": "card index dividers",
     "shortname": ":dividers:",
@@ -11632,7 +11632,7 @@
     ]
   },
   "card_box": {
-    "unicode": "1F5C3",
+    "unicode": "1f5c3",
     "unicode_alternates": [],
     "name": "card file box",
     "shortname": ":card_box:",
@@ -11648,7 +11648,7 @@
     ]
   },
   "link": {
-    "unicode": "1F517",
+    "unicode": "1f517",
     "unicode_alternates": [],
     "name": "link symbol",
     "shortname": ":link:",
@@ -11662,7 +11662,7 @@
     ]
   },
   "paperclip": {
-    "unicode": "1F4CE",
+    "unicode": "1f4ce",
     "unicode_alternates": [],
     "name": "paperclip",
     "shortname": ":paperclip:",
@@ -11676,7 +11676,7 @@
     ]
   },
   "paperclips": {
-    "unicode": "1F587",
+    "unicode": "1f587",
     "unicode_alternates": [],
     "name": "linked paperclips",
     "shortname": ":paperclips:",
@@ -11692,7 +11692,7 @@
     ]
   },
   "pushpin": {
-    "unicode": "1F4CC",
+    "unicode": "1f4cc",
     "unicode_alternates": [],
     "name": "pushpin",
     "shortname": ":pushpin:",
@@ -11705,7 +11705,7 @@
     ]
   },
   "pushpin_black": {
-    "unicode": "1F588",
+    "unicode": "1f588",
     "unicode_alternates": [],
     "name": "black pushpin",
     "shortname": ":pushpin_black:",
@@ -11734,7 +11734,7 @@
     ]
   },
   "triangular_ruler": {
-    "unicode": "1F4D0",
+    "unicode": "1f4d0",
     "unicode_alternates": [],
     "name": "triangular ruler",
     "shortname": ":triangular_ruler:",
@@ -11750,7 +11750,7 @@
     ]
   },
   "round_pushpin": {
-    "unicode": "1F4CD",
+    "unicode": "1f4cd",
     "unicode_alternates": [],
     "name": "round pushpin",
     "shortname": ":round_pushpin:",
@@ -11763,7 +11763,7 @@
     ]
   },
   "straight_ruler": {
-    "unicode": "1F4CF",
+    "unicode": "1f4cf",
     "unicode_alternates": [],
     "name": "straight ruler",
     "shortname": ":straight_ruler:",
@@ -11776,7 +11776,7 @@
     ]
   },
   "triangular_flag_on_post": {
-    "unicode": "1F6A9",
+    "unicode": "1f6a9",
     "unicode_alternates": [],
     "name": "triangular flag on post",
     "shortname": ":triangular_flag_on_post:",
@@ -11791,7 +11791,7 @@
     ]
   },
   "pennant_white": {
-    "unicode": "1F3F1",
+    "unicode": "1f3f1",
     "unicode_alternates": [],
     "name": "white pennant",
     "shortname": ":pennant_white:",
@@ -11807,7 +11807,7 @@
     ]
   },
   "pennant_black": {
-    "unicode": "1F3F2",
+    "unicode": "1f3f2",
     "unicode_alternates": [],
     "name": "black pennant",
     "shortname": ":pennant_black:",
@@ -11823,7 +11823,7 @@
     ]
   },
   "flag_white": {
-    "unicode": "1F3F3",
+    "unicode": "1f3f3",
     "unicode_alternates": [],
     "name": "waving white flag",
     "shortname": ":flag_white:",
@@ -11839,7 +11839,7 @@
     ]
   },
   "flag_black": {
-    "unicode": "1F3F4",
+    "unicode": "1f3f4",
     "unicode_alternates": [],
     "name": "waving black flag",
     "shortname": ":flag_black:",
@@ -11855,7 +11855,7 @@
     ]
   },
   "hole": {
-    "unicode": "1F573",
+    "unicode": "1f573",
     "unicode_alternates": [],
     "name": "hole",
     "shortname": ":hole:",
@@ -11869,7 +11869,7 @@
     ]
   },
   "folder": {
-    "unicode": "1F5C0",
+    "unicode": "1f5c0",
     "unicode_alternates": [],
     "name": "folder",
     "shortname": ":folder:",
@@ -11882,7 +11882,7 @@
     ]
   },
   "folder_open": {
-    "unicode": "1F5C1",
+    "unicode": "1f5c1",
     "unicode_alternates": [],
     "name": "open folder",
     "shortname": ":folder_open:",
@@ -11898,7 +11898,7 @@
     ]
   },
   "file_folder": {
-    "unicode": "1F4C1",
+    "unicode": "1f4c1",
     "unicode_alternates": [],
     "name": "file folder",
     "shortname": ":file_folder:",
@@ -11911,7 +11911,7 @@
     ]
   },
   "open_file_folder": {
-    "unicode": "1F4C2",
+    "unicode": "1f4c2",
     "unicode_alternates": [],
     "name": "open file folder",
     "shortname": ":open_file_folder:",
@@ -11925,7 +11925,7 @@
     ]
   },
   "file_cabinet": {
-    "unicode": "1F5C4",
+    "unicode": "1f5c4",
     "unicode_alternates": [],
     "name": "file cabinet",
     "shortname": ":file_cabinet:",
@@ -11957,7 +11957,7 @@
     ]
   },
   "pencil2": {
-    "unicode": "270F",
+    "unicode": "270f",
     "unicode_alternates": [
       "270F-FE0F"
     ],
@@ -11974,7 +11974,7 @@
     ]
   },
   "pencil3": {
-    "unicode": "1F589",
+    "unicode": "1f589",
     "unicode_alternates": [],
     "name": "lower left pencil",
     "shortname": ":pencil3:",
@@ -11991,7 +11991,7 @@
     ]
   },
   "pen_ballpoint": {
-    "unicode": "1F58A",
+    "unicode": "1f58a",
     "unicode_alternates": [],
     "name": "lower left ballpoint pen",
     "shortname": ":pen_ballpoint:",
@@ -12008,7 +12008,7 @@
     ]
   },
   "pen_fountain": {
-    "unicode": "1F58B",
+    "unicode": "1f58b",
     "unicode_alternates": [],
     "name": "lower left fountain pen",
     "shortname": ":pen_fountain:",
@@ -12025,7 +12025,7 @@
     ]
   },
   "paintbrush": {
-    "unicode": "1F58C",
+    "unicode": "1f58c",
     "unicode_alternates": [],
     "name": "lower left paintbrush",
     "shortname": ":paintbrush:",
@@ -12042,7 +12042,7 @@
     ]
   },
   "crayon": {
-    "unicode": "1F58D",
+    "unicode": "1f58d",
     "unicode_alternates": [],
     "name": "lower left crayon",
     "shortname": ":crayon:",
@@ -12060,7 +12060,7 @@
     ]
   },
   "pencil": {
-    "unicode": "1F4DD",
+    "unicode": "1f4dd",
     "unicode_alternates": [],
     "name": "memo",
     "shortname": ":pencil:",
@@ -12077,7 +12077,7 @@
     ]
   },
   "lock_with_ink_pen": {
-    "unicode": "1F50F",
+    "unicode": "1f50f",
     "unicode_alternates": [],
     "name": "lock with ink pen",
     "shortname": ":lock_with_ink_pen:",
@@ -12091,7 +12091,7 @@
     ]
   },
   "closed_lock_with_key": {
-    "unicode": "1F510",
+    "unicode": "1f510",
     "unicode_alternates": [],
     "name": "closed lock with key",
     "shortname": ":closed_lock_with_key:",
@@ -12105,7 +12105,7 @@
     ]
   },
   "lock": {
-    "unicode": "1F512",
+    "unicode": "1f512",
     "unicode_alternates": [],
     "name": "lock",
     "shortname": ":lock:",
@@ -12119,7 +12119,7 @@
     ]
   },
   "unlock": {
-    "unicode": "1F513",
+    "unicode": "1f513",
     "unicode_alternates": [],
     "name": "open lock",
     "shortname": ":unlock:",
@@ -12134,7 +12134,7 @@
     ]
   },
   "mega": {
-    "unicode": "1F4E3",
+    "unicode": "1f4e3",
     "unicode_alternates": [],
     "name": "cheering megaphone",
     "shortname": ":mega:",
@@ -12149,7 +12149,7 @@
     ]
   },
   "loudspeaker": {
-    "unicode": "1F4E2",
+    "unicode": "1f4e2",
     "unicode_alternates": [],
     "name": "public address loudspeaker",
     "shortname": ":loudspeaker:",
@@ -12163,7 +12163,7 @@
     ]
   },
   "speaker": {
-    "unicode": "1F508",
+    "unicode": "1f508",
     "unicode_alternates": [],
     "name": "speaker",
     "shortname": ":speaker:",
@@ -12180,7 +12180,7 @@
     ]
   },
   "sound": {
-    "unicode": "1F509",
+    "unicode": "1f509",
     "unicode_alternates": [],
     "name": "speaker with one sound wave",
     "shortname": ":sound:",
@@ -12194,7 +12194,7 @@
     ]
   },
   "loud_sound": {
-    "unicode": "1F50A",
+    "unicode": "1f50a",
     "unicode_alternates": [],
     "name": "speaker with three sound waves",
     "shortname": ":loud_sound:",
@@ -12209,7 +12209,7 @@
     ]
   },
   "mute": {
-    "unicode": "1F507",
+    "unicode": "1f507",
     "unicode_alternates": [],
     "name": "speaker with cancellation stroke",
     "shortname": ":mute:",
@@ -12224,7 +12224,7 @@
     ]
   },
   "right_speaker": {
-    "unicode": "1F568",
+    "unicode": "1f568",
     "unicode_alternates": [],
     "name": "right speaker",
     "shortname": ":right_speaker:",
@@ -12241,7 +12241,7 @@
     ]
   },
   "right_speaker_one": {
-    "unicode": "1F569",
+    "unicode": "1f569",
     "unicode_alternates": [],
     "name": "right speaker with one sound wave",
     "shortname": ":right_speaker_one:",
@@ -12257,7 +12257,7 @@
     ]
   },
   "right_speaker_three": {
-    "unicode": "1F56A",
+    "unicode": "1f56a",
     "unicode_alternates": [],
     "name": "right speaker with three sound waves",
     "shortname": ":right_speaker_three:",
@@ -12274,7 +12274,7 @@
     ]
   },
   "bullhorn": {
-    "unicode": "1F56B",
+    "unicode": "1f56b",
     "unicode_alternates": [],
     "name": "bullhorn",
     "shortname": ":bullhorn:",
@@ -12290,7 +12290,7 @@
     ]
   },
   "bullhorn_waves": {
-    "unicode": "1F56C",
+    "unicode": "1f56c",
     "unicode_alternates": [],
     "name": "bullhorn with sound waves",
     "shortname": ":bullhorn_waves:",
@@ -12308,7 +12308,7 @@
     ]
   },
   "zzz": {
-    "unicode": "1F4A4",
+    "unicode": "1f4a4",
     "unicode_alternates": [],
     "name": "sleeping symbol",
     "shortname": ":zzz:",
@@ -12323,7 +12323,7 @@
     ]
   },
   "bell": {
-    "unicode": "1F514",
+    "unicode": "1f514",
     "unicode_alternates": [],
     "name": "bell",
     "shortname": ":bell:",
@@ -12341,7 +12341,7 @@
     ]
   },
   "no_bell": {
-    "unicode": "1F515",
+    "unicode": "1f515",
     "unicode_alternates": [],
     "name": "bell with cancellation stroke",
     "shortname": ":no_bell:",
@@ -12357,7 +12357,7 @@
     ]
   },
   "ringing_bell": {
-    "unicode": "1F56D",
+    "unicode": "1f56d",
     "unicode_alternates": [],
     "name": "ringing bell",
     "shortname": ":ringing_bell:",
@@ -12374,7 +12374,7 @@
     ]
   },
   "ascending_notes": {
-    "unicode": "1F39C",
+    "unicode": "1f39c",
     "unicode_alternates": [],
     "name": "beamed ascending musical notes",
     "shortname": ":ascending_notes:",
@@ -12390,7 +12390,7 @@
     ]
   },
   "descending_notes": {
-    "unicode": "1F39D",
+    "unicode": "1f39d",
     "unicode_alternates": [],
     "name": "beamed descending musical notes",
     "shortname": ":descending_notes:",
@@ -12406,7 +12406,7 @@
     ]
   },
   "cross_white": {
-    "unicode": "1F546",
+    "unicode": "1f546",
     "unicode_alternates": [],
     "name": "white latin cross",
     "shortname": ":cross_white:",
@@ -12422,7 +12422,7 @@
     ]
   },
   "cross_heavy": {
-    "unicode": "1F547",
+    "unicode": "1f547",
     "unicode_alternates": [],
     "name": "heavy latin cross",
     "shortname": ":cross_heavy:",
@@ -12438,7 +12438,7 @@
     ]
   },
   "celtic_cross": {
-    "unicode": "1F548",
+    "unicode": "1f548",
     "unicode_alternates": [],
     "name": "celtic cross",
     "shortname": ":celtic_cross:",
@@ -12452,7 +12452,7 @@
     ]
   },
   "om_symbol": {
-    "unicode": "1F549",
+    "unicode": "1f549",
     "unicode_alternates": [],
     "name": "om symbol",
     "shortname": ":om_symbol:",
@@ -12472,7 +12472,7 @@
     ]
   },
   "dove": {
-    "unicode": "1F54A",
+    "unicode": "1f54a",
     "unicode_alternates": [],
     "name": "dove of peace",
     "shortname": ":dove:",
@@ -12488,7 +12488,7 @@
     ]
   },
   "thought_balloon": {
-    "unicode": "1F4AD",
+    "unicode": "1f4ad",
     "unicode_alternates": [],
     "name": "thought balloon",
     "shortname": ":thought_balloon:",
@@ -12506,7 +12506,7 @@
     ]
   },
   "speech_balloon": {
-    "unicode": "1F4AC",
+    "unicode": "1f4ac",
     "unicode_alternates": [],
     "name": "speech balloon",
     "shortname": ":speech_balloon:",
@@ -12525,7 +12525,7 @@
     ]
   },
   "speech_left": {
-    "unicode": "1F5E8",
+    "unicode": "1f5e8",
     "unicode_alternates": [],
     "name": "left speech bubble",
     "shortname": ":speech_left:",
@@ -12546,7 +12546,7 @@
     ]
   },
   "speech_right": {
-    "unicode": "1F5E9",
+    "unicode": "1f5e9",
     "unicode_alternates": [],
     "name": "right speech bubble",
     "shortname": ":speech_right:",
@@ -12567,7 +12567,7 @@
     ]
   },
   "speech_two": {
-    "unicode": "1F5EA",
+    "unicode": "1f5ea",
     "unicode_alternates": [],
     "name": "two speech bubbles",
     "shortname": ":speech_two:",
@@ -12588,7 +12588,7 @@
     ]
   },
   "speech_three": {
-    "unicode": "1F5EB",
+    "unicode": "1f5eb",
     "unicode_alternates": [],
     "name": "three speech bubbles",
     "shortname": ":speech_three:",
@@ -12609,7 +12609,7 @@
     ]
   },
   "thought_left": {
-    "unicode": "1F5EC",
+    "unicode": "1f5ec",
     "unicode_alternates": [],
     "name": "left thought bubble",
     "shortname": ":thought_left:",
@@ -12629,7 +12629,7 @@
     ]
   },
   "thought_right": {
-    "unicode": "1F5ED",
+    "unicode": "1f5ed",
     "unicode_alternates": [],
     "name": "right thought bubble",
     "shortname": ":thought_right:",
@@ -12649,7 +12649,7 @@
     ]
   },
   "anger_left": {
-    "unicode": "1F5EE",
+    "unicode": "1f5ee",
     "unicode_alternates": [],
     "name": "left anger bubble",
     "shortname": ":anger_left:",
@@ -12671,7 +12671,7 @@
     ]
   },
   "anger_right": {
-    "unicode": "1F5EF",
+    "unicode": "1f5ef",
     "unicode_alternates": [],
     "name": "right anger bubble",
     "shortname": ":anger_right:",
@@ -12693,7 +12693,7 @@
     ]
   },
   "mood_bubble": {
-    "unicode": "1F5F0",
+    "unicode": "1f5f0",
     "unicode_alternates": [],
     "name": "mood bubble",
     "shortname": ":mood_bubble:",
@@ -12710,7 +12710,7 @@
     ]
   },
   "mood_bubble_lightning": {
-    "unicode": "1F5F1",
+    "unicode": "1f5f1",
     "unicode_alternates": [],
     "name": "lightning mood bubble",
     "shortname": ":mood_bubble_lightning:",
@@ -12729,7 +12729,7 @@
     ]
   },
   "children_crossing": {
-    "unicode": "1F6B8",
+    "unicode": "1f6b8",
     "unicode_alternates": [],
     "name": "children crossing",
     "shortname": ":children_crossing:",
@@ -12748,7 +12748,7 @@
     ]
   },
   "shield": {
-    "unicode": "1F6E1",
+    "unicode": "1f6e1",
     "unicode_alternates": [],
     "name": "shield",
     "shortname": ":shield:",
@@ -12765,7 +12765,7 @@
     ]
   },
   "mag": {
-    "unicode": "1F50D",
+    "unicode": "1f50d",
     "unicode_alternates": [],
     "name": "left-pointing magnifying glass",
     "shortname": ":mag:",
@@ -12782,7 +12782,7 @@
     ]
   },
   "mag_right": {
-    "unicode": "1F50E",
+    "unicode": "1f50e",
     "unicode_alternates": [],
     "name": "right-pointing magnifying glass",
     "shortname": ":mag_right:",
@@ -12799,7 +12799,7 @@
     ]
   },
   "speaking_head": {
-    "unicode": "1F5E3",
+    "unicode": "1f5e3",
     "unicode_alternates": [],
     "name": "speaking head in silhouette",
     "shortname": ":speaking_head:",
@@ -12814,7 +12814,7 @@
     ]
   },
   "sleeping_accommodation": {
-    "unicode": "1F6CC",
+    "unicode": "1f6cc",
     "unicode_alternates": [],
     "name": "sleeping accommodation",
     "shortname": ":sleeping_accommodation:",
@@ -12829,7 +12829,7 @@
     ]
   },
   "prohibited": {
-    "unicode": "1F6C7",
+    "unicode": "1f6c7",
     "unicode_alternates": [],
     "name": "prohibited sign",
     "shortname": ":prohibited:",
@@ -12850,7 +12850,7 @@
     ]
   },
   "no_entry_sign": {
-    "unicode": "1F6AB",
+    "unicode": "1f6ab",
     "unicode_alternates": [],
     "name": "no entry sign",
     "shortname": ":no_entry_sign:",
@@ -12868,7 +12868,7 @@
     ]
   },
   "no_entry": {
-    "unicode": "26D4",
+    "unicode": "26d4",
     "unicode_alternates": [
       "26D4-FE0F"
     ],
@@ -12888,7 +12888,7 @@
     ]
   },
   "name_badge": {
-    "unicode": "1F4DB",
+    "unicode": "1f4db",
     "unicode_alternates": [],
     "name": "name badge",
     "shortname": ":name_badge:",
@@ -12901,7 +12901,7 @@
     ]
   },
   "no_pedestrians": {
-    "unicode": "1F6B7",
+    "unicode": "1f6b7",
     "unicode_alternates": [],
     "name": "no pedestrians",
     "shortname": ":no_pedestrians:",
@@ -12919,7 +12919,7 @@
     ]
   },
   "do_not_litter": {
-    "unicode": "1F6AF",
+    "unicode": "1f6af",
     "unicode_alternates": [],
     "name": "do not litter symbol",
     "shortname": ":do_not_litter:",
@@ -12936,7 +12936,7 @@
     ]
   },
   "no_bicycles": {
-    "unicode": "1F6B3",
+    "unicode": "1f6b3",
     "unicode_alternates": [],
     "name": "no bicycles",
     "shortname": ":no_bicycles:",
@@ -12952,7 +12952,7 @@
     ]
   },
   "non-potable_water": {
-    "unicode": "1F6B1",
+    "unicode": "1f6b1",
     "unicode_alternates": [],
     "name": "non-potable water symbol",
     "shortname": ":non-potable_water:",
@@ -12972,7 +12972,7 @@
     ]
   },
   "no_mobile_phones": {
-    "unicode": "1F4F5",
+    "unicode": "1f4f5",
     "unicode_alternates": [],
     "name": "no mobile phones",
     "shortname": ":no_mobile_phones:",
@@ -12986,7 +12986,7 @@
     ]
   },
   "underage": {
-    "unicode": "1F51E",
+    "unicode": "1f51e",
     "unicode_alternates": [],
     "name": "no one under eighteen symbol",
     "shortname": ":underage:",
@@ -13002,7 +13002,7 @@
     ]
   },
   "piracy": {
-    "unicode": "1F572",
+    "unicode": "1f572",
     "unicode_alternates": [],
     "name": "no piracy",
     "shortname": ":piracy:",
@@ -13018,7 +13018,7 @@
     ]
   },
   "accept": {
-    "unicode": "1F251",
+    "unicode": "1f251",
     "unicode_alternates": [],
     "name": "circled ideograph accept",
     "shortname": ":accept:",
@@ -13036,7 +13036,7 @@
     ]
   },
   "ideograph_advantage": {
-    "unicode": "1F250",
+    "unicode": "1f250",
     "unicode_alternates": [],
     "name": "circled ideograph advantage",
     "shortname": ":ideograph_advantage:",
@@ -13052,7 +13052,7 @@
     ]
   },
   "white_flower": {
-    "unicode": "1F4AE",
+    "unicode": "1f4ae",
     "unicode_alternates": [],
     "name": "white flower",
     "shortname": ":white_flower:",
@@ -13107,7 +13107,7 @@
     ]
   },
   "u5408": {
-    "unicode": "1F234",
+    "unicode": "1f234",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-5408",
     "shortname": ":u5408:",
@@ -13125,7 +13125,7 @@
     ]
   },
   "u6e80": {
-    "unicode": "1F235",
+    "unicode": "1f235",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-6e80",
     "shortname": ":u6e80:",
@@ -13142,7 +13142,7 @@
     ]
   },
   "u7981": {
-    "unicode": "1F232",
+    "unicode": "1f232",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-7981",
     "shortname": ":u7981:",
@@ -13162,7 +13162,7 @@
     ]
   },
   "u6709": {
-    "unicode": "1F236",
+    "unicode": "1f236",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-6709",
     "shortname": ":u6709:",
@@ -13179,7 +13179,7 @@
     ]
   },
   "u7121": {
-    "unicode": "1F21A",
+    "unicode": "1f21a",
     "unicode_alternates": [
       "1F21A-FE0F"
     ],
@@ -13199,7 +13199,7 @@
     ]
   },
   "u7533": {
-    "unicode": "1F238",
+    "unicode": "1f238",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-7533",
     "shortname": ":u7533:",
@@ -13216,7 +13216,7 @@
     ]
   },
   "u55b6": {
-    "unicode": "1F23A",
+    "unicode": "1f23a",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-55b6",
     "shortname": ":u55b6:",
@@ -13231,7 +13231,7 @@
     ]
   },
   "u6708": {
-    "unicode": "1F237",
+    "unicode": "1f237",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-6708",
     "shortname": ":u6708:",
@@ -13249,7 +13249,7 @@
     ]
   },
   "u5272": {
-    "unicode": "1F239",
+    "unicode": "1f239",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-5272",
     "shortname": ":u5272:",
@@ -13268,7 +13268,7 @@
     ]
   },
   "u7a7a": {
-    "unicode": "1F233",
+    "unicode": "1f233",
     "unicode_alternates": [],
     "name": "squared cjk unified ideograph-7a7a",
     "shortname": ":u7a7a:",
@@ -13284,7 +13284,7 @@
     ]
   },
   "sa": {
-    "unicode": "1F202",
+    "unicode": "1f202",
     "unicode_alternates": [],
     "name": "squared katakana sa",
     "shortname": ":sa:",
@@ -13298,7 +13298,7 @@
     ]
   },
   "koko": {
-    "unicode": "1F201",
+    "unicode": "1f201",
     "unicode_alternates": [],
     "name": "squared katakana koko",
     "shortname": ":koko:",
@@ -13314,7 +13314,7 @@
     ]
   },
   "u6307": {
-    "unicode": "1F22F",
+    "unicode": "1f22f",
     "unicode_alternates": [
       "1F22F-FE0F"
     ],
@@ -13332,7 +13332,7 @@
     ]
   },
   "chart": {
-    "unicode": "1F4B9",
+    "unicode": "1f4b9",
     "unicode_alternates": [],
     "name": "chart with upwards trend and yen sign",
     "shortname": ":chart:",
@@ -13379,7 +13379,7 @@
     ]
   },
   "negative_squared_cross_mark": {
-    "unicode": "274E",
+    "unicode": "274e",
     "unicode_alternates": [],
     "name": "negative squared cross mark",
     "shortname": ":negative_squared_cross_mark:",
@@ -13426,7 +13426,7 @@
     ]
   },
   "vibration_mode": {
-    "unicode": "1F4F3",
+    "unicode": "1f4f3",
     "unicode_alternates": [],
     "name": "vibration mode",
     "shortname": ":vibration_mode:",
@@ -13441,7 +13441,7 @@
     ]
   },
   "mobile_phone_off": {
-    "unicode": "1F4F4",
+    "unicode": "1f4f4",
     "unicode_alternates": [],
     "name": "mobile phone off",
     "shortname": ":mobile_phone_off:",
@@ -13454,7 +13454,7 @@
     ]
   },
   "vs": {
-    "unicode": "1F19A",
+    "unicode": "1f19a",
     "unicode_alternates": [],
     "name": "squared vs",
     "shortname": ":vs:",
@@ -13469,7 +13469,7 @@
     ]
   },
   "a": {
-    "unicode": "1F170",
+    "unicode": "1f170",
     "unicode_alternates": [],
     "name": "negative squared latin capital letter a",
     "shortname": ":a:",
@@ -13486,7 +13486,7 @@
     ]
   },
   "b": {
-    "unicode": "1F171",
+    "unicode": "1f171",
     "unicode_alternates": [],
     "name": "negative squared latin capital letter b",
     "shortname": ":b:",
@@ -13503,7 +13503,7 @@
     ]
   },
   "ab": {
-    "unicode": "1F18E",
+    "unicode": "1f18e",
     "unicode_alternates": [],
     "name": "negative squared ab",
     "shortname": ":ab:",
@@ -13519,7 +13519,7 @@
     ]
   },
   "cl": {
-    "unicode": "1F191",
+    "unicode": "1f191",
     "unicode_alternates": [],
     "name": "squared cl",
     "shortname": ":cl:",
@@ -13536,7 +13536,7 @@
     ]
   },
   "o2": {
-    "unicode": "1F17E",
+    "unicode": "1f17e",
     "unicode_alternates": [],
     "name": "negative squared latin capital letter o",
     "shortname": ":o2:",
@@ -13553,7 +13553,7 @@
     ]
   },
   "sos": {
-    "unicode": "1F198",
+    "unicode": "1f198",
     "unicode_alternates": [],
     "name": "squared sos",
     "shortname": ":sos:",
@@ -13569,7 +13569,7 @@
     ]
   },
   "id": {
-    "unicode": "1F194",
+    "unicode": "1f194",
     "unicode_alternates": [],
     "name": "squared id",
     "shortname": ":id:",
@@ -13583,7 +13583,7 @@
     ]
   },
   "parking": {
-    "unicode": "1F17F",
+    "unicode": "1f17f",
     "unicode_alternates": [
       "1F17F-FE0F"
     ],
@@ -13602,7 +13602,7 @@
     ]
   },
   "wc": {
-    "unicode": "1F6BE",
+    "unicode": "1f6be",
     "unicode_alternates": [],
     "name": "water closet",
     "shortname": ":wc:",
@@ -13624,7 +13624,7 @@
     ]
   },
   "cool": {
-    "unicode": "1F192",
+    "unicode": "1f192",
     "unicode_alternates": [],
     "name": "squared cool",
     "shortname": ":cool:",
@@ -13638,7 +13638,7 @@
     ]
   },
   "free": {
-    "unicode": "1F193",
+    "unicode": "1f193",
     "unicode_alternates": [],
     "name": "squared free",
     "shortname": ":free:",
@@ -13652,7 +13652,7 @@
     ]
   },
   "new": {
-    "unicode": "1F195",
+    "unicode": "1f195",
     "unicode_alternates": [],
     "name": "squared new",
     "shortname": ":new:",
@@ -13665,7 +13665,7 @@
     ]
   },
   "ng": {
-    "unicode": "1F196",
+    "unicode": "1f196",
     "unicode_alternates": [],
     "name": "squared ng",
     "shortname": ":ng:",
@@ -13679,7 +13679,7 @@
     ]
   },
   "ok": {
-    "unicode": "1F197",
+    "unicode": "1f197",
     "unicode_alternates": [],
     "name": "squared ok",
     "shortname": ":ok:",
@@ -13695,7 +13695,7 @@
     ]
   },
   "up": {
-    "unicode": "1F199",
+    "unicode": "1f199",
     "unicode_alternates": [],
     "name": "squared up with exclamation mark",
     "shortname": ":up:",
@@ -13708,7 +13708,7 @@
     ]
   },
   "atm": {
-    "unicode": "1F3E7",
+    "unicode": "1f3e7",
     "unicode_alternates": [],
     "name": "automated teller machine",
     "shortname": ":atm:",
@@ -13777,7 +13777,7 @@
     ]
   },
   "gemini": {
-    "unicode": "264A",
+    "unicode": "264a",
     "unicode_alternates": [
       "264A-FE0F"
     ],
@@ -13799,7 +13799,7 @@
     ]
   },
   "cancer": {
-    "unicode": "264B",
+    "unicode": "264b",
     "unicode_alternates": [
       "264B-FE0F"
     ],
@@ -13821,7 +13821,7 @@
     ]
   },
   "leo": {
-    "unicode": "264C",
+    "unicode": "264c",
     "unicode_alternates": [
       "264C-FE0F"
     ],
@@ -13844,7 +13844,7 @@
     ]
   },
   "virgo": {
-    "unicode": "264D",
+    "unicode": "264d",
     "unicode_alternates": [
       "264D-FE0F"
     ],
@@ -13866,7 +13866,7 @@
     ]
   },
   "libra": {
-    "unicode": "264E",
+    "unicode": "264e",
     "unicode_alternates": [
       "264E-FE0F"
     ],
@@ -13889,7 +13889,7 @@
     ]
   },
   "scorpius": {
-    "unicode": "264F",
+    "unicode": "264f",
     "unicode_alternates": [
       "264F-FE0F"
     ],
@@ -14005,7 +14005,7 @@
     ]
   },
   "restroom": {
-    "unicode": "1F6BB",
+    "unicode": "1f6bb",
     "unicode_alternates": [],
     "name": "restroom",
     "shortname": ":restroom:",
@@ -14024,7 +14024,7 @@
     ]
   },
   "mens": {
-    "unicode": "1F6B9",
+    "unicode": "1f6b9",
     "unicode_alternates": [],
     "name": "mens symbol",
     "shortname": ":mens:",
@@ -14045,7 +14045,7 @@
     ]
   },
   "womens": {
-    "unicode": "1F6BA",
+    "unicode": "1f6ba",
     "unicode_alternates": [],
     "name": "womens symbol",
     "shortname": ":womens:",
@@ -14065,7 +14065,7 @@
     ]
   },
   "boys_symbol": {
-    "unicode": "1F6C9",
+    "unicode": "1f6c9",
     "unicode_alternates": [],
     "name": "boys symbol",
     "shortname": ":boys_symbol:",
@@ -14079,7 +14079,7 @@
     ]
   },
   "girls_symbol": {
-    "unicode": "1F6CA",
+    "unicode": "1f6ca",
     "unicode_alternates": [],
     "name": "girls symbol",
     "shortname": ":girls_symbol:",
@@ -14093,7 +14093,7 @@
     ]
   },
   "baby_symbol": {
-    "unicode": "1F6BC",
+    "unicode": "1f6bc",
     "unicode_alternates": [],
     "name": "baby symbol",
     "shortname": ":baby_symbol:",
@@ -14113,7 +14113,7 @@
     ]
   },
   "wheelchair": {
-    "unicode": "267F",
+    "unicode": "267f",
     "unicode_alternates": [
       "267F-FE0F"
     ],
@@ -14130,7 +14130,7 @@
     ]
   },
   "potable_water": {
-    "unicode": "1F6B0",
+    "unicode": "1f6b0",
     "unicode_alternates": [],
     "name": "potable water symbol",
     "shortname": ":potable_water:",
@@ -14151,7 +14151,7 @@
     ]
   },
   "no_smoking": {
-    "unicode": "1F6AD",
+    "unicode": "1f6ad",
     "unicode_alternates": [],
     "name": "no smoking symbol",
     "shortname": ":no_smoking:",
@@ -14170,7 +14170,7 @@
     ]
   },
   "put_litter_in_its_place": {
-    "unicode": "1F6AE",
+    "unicode": "1f6ae",
     "unicode_alternates": [],
     "name": "put litter in its place symbol",
     "shortname": ":put_litter_in_its_place:",
@@ -14188,7 +14188,7 @@
     ]
   },
   "arrow_forward": {
-    "unicode": "25B6",
+    "unicode": "25b6",
     "unicode_alternates": [
       "25B6-FE0F"
     ],
@@ -14205,7 +14205,7 @@
     ]
   },
   "arrow_backward": {
-    "unicode": "25C0",
+    "unicode": "25c0",
     "unicode_alternates": [
       "25C0-FE0F"
     ],
@@ -14222,7 +14222,7 @@
     ]
   },
   "arrow_up_small": {
-    "unicode": "1F53C",
+    "unicode": "1f53c",
     "unicode_alternates": [],
     "name": "up-pointing small red triangle",
     "shortname": ":arrow_up_small:",
@@ -14236,7 +14236,7 @@
     ]
   },
   "arrow_down_small": {
-    "unicode": "1F53D",
+    "unicode": "1f53d",
     "unicode_alternates": [],
     "name": "down-pointing small red triangle",
     "shortname": ":arrow_down_small:",
@@ -14250,7 +14250,7 @@
     ]
   },
   "fast_forward": {
-    "unicode": "23E9",
+    "unicode": "23e9",
     "unicode_alternates": [],
     "name": "black right-pointing double triangle",
     "shortname": ":fast_forward:",
@@ -14265,7 +14265,7 @@
     ]
   },
   "rewind": {
-    "unicode": "23EA",
+    "unicode": "23ea",
     "unicode_alternates": [],
     "name": "black left-pointing double triangle",
     "shortname": ":rewind:",
@@ -14280,7 +14280,7 @@
     ]
   },
   "arrow_double_up": {
-    "unicode": "23EB",
+    "unicode": "23eb",
     "unicode_alternates": [],
     "name": "black up-pointing double triangle",
     "shortname": ":arrow_double_up:",
@@ -14294,7 +14294,7 @@
     ]
   },
   "arrow_double_down": {
-    "unicode": "23EC",
+    "unicode": "23ec",
     "unicode_alternates": [],
     "name": "black down-pointing double triangle",
     "shortname": ":arrow_double_down:",
@@ -14308,7 +14308,7 @@
     ]
   },
   "arrow_right": {
-    "unicode": "27A1",
+    "unicode": "27a1",
     "unicode_alternates": [
       "27A1-FE0F"
     ],
@@ -14326,7 +14326,7 @@
     ]
   },
   "arrow_left": {
-    "unicode": "2B05",
+    "unicode": "2b05",
     "unicode_alternates": [
       "2B05-FE0F"
     ],
@@ -14344,7 +14344,7 @@
     ]
   },
   "arrow_up": {
-    "unicode": "2B06",
+    "unicode": "2b06",
     "unicode_alternates": [
       "2B06-FE0F"
     ],
@@ -14360,7 +14360,7 @@
     ]
   },
   "arrow_down": {
-    "unicode": "2B07",
+    "unicode": "2b07",
     "unicode_alternates": [
       "2B07-FE0F"
     ],
@@ -14474,7 +14474,7 @@
     ]
   },
   "arrows_counterclockwise": {
-    "unicode": "1F504",
+    "unicode": "1f504",
     "unicode_alternates": [],
     "name": "anticlockwise downwards and upwards open circle arrows",
     "shortname": ":arrows_counterclockwise:",
@@ -14489,7 +14489,7 @@
     ]
   },
   "arrow_right_hook": {
-    "unicode": "21AA",
+    "unicode": "21aa",
     "unicode_alternates": [
       "21AA-FE0F"
     ],
@@ -14506,7 +14506,7 @@
     ]
   },
   "leftwards_arrow_with_hook": {
-    "unicode": "21A9",
+    "unicode": "21a9",
     "unicode_alternates": [
       "21A9-FE0F"
     ],
@@ -14557,7 +14557,7 @@
     ]
   },
   "twisted_rightwards_arrows": {
-    "unicode": "1F500",
+    "unicode": "1f500",
     "unicode_alternates": [],
     "name": "twisted rightwards arrows",
     "shortname": ":twisted_rightwards_arrows:",
@@ -14570,7 +14570,7 @@
     ]
   },
   "repeat": {
-    "unicode": "1F501",
+    "unicode": "1f501",
     "unicode_alternates": [],
     "name": "clockwise rightwards and leftwards open circle arrows",
     "shortname": ":repeat:",
@@ -14585,7 +14585,7 @@
     ]
   },
   "repeat_one": {
-    "unicode": "1F502",
+    "unicode": "1f502",
     "unicode_alternates": [],
     "name": "clockwise rightwards and leftwards open circle arrows",
     "shortname": ":repeat_one:",
@@ -14788,7 +14788,7 @@
     ]
   },
   "keycap_ten": {
-    "unicode": "1F51F",
+    "unicode": "1f51f",
     "unicode_alternates": [],
     "name": "keycap ten",
     "shortname": ":keycap_ten:",
@@ -14803,7 +14803,7 @@
     ]
   },
   "1234": {
-    "unicode": "1F522",
+    "unicode": "1f522",
     "unicode_alternates": [],
     "name": "input symbol for numbers",
     "shortname": ":1234:",
@@ -14816,7 +14816,7 @@
     ]
   },
   "abc": {
-    "unicode": "1F524",
+    "unicode": "1f524",
     "unicode_alternates": [],
     "name": "input symbol for latin letters",
     "shortname": ":abc:",
@@ -14830,7 +14830,7 @@
     ]
   },
   "abcd": {
-    "unicode": "1F521",
+    "unicode": "1f521",
     "unicode_alternates": [],
     "name": "input symbol for latin small letters",
     "shortname": ":abcd:",
@@ -14844,7 +14844,7 @@
     ]
   },
   "capital_abcd": {
-    "unicode": "1F520",
+    "unicode": "1f520",
     "unicode_alternates": [],
     "name": "input symbol for latin capital letters",
     "shortname": ":capital_abcd:",
@@ -14875,7 +14875,7 @@
     ]
   },
   "signal_strength": {
-    "unicode": "1F4F6",
+    "unicode": "1f4f6",
     "unicode_alternates": [],
     "name": "antenna with bars",
     "shortname": ":signal_strength:",
@@ -14889,7 +14889,7 @@
     ]
   },
   "cinema": {
-    "unicode": "1F3A6",
+    "unicode": "1f3a6",
     "unicode_alternates": [],
     "name": "cinema",
     "shortname": ":cinema:",
@@ -14908,7 +14908,7 @@
     ]
   },
   "symbols": {
-    "unicode": "1F523",
+    "unicode": "1f523",
     "unicode_alternates": [],
     "name": "input symbol for symbols",
     "shortname": ":symbols:",
@@ -15017,7 +15017,7 @@
     ]
   },
   "cancellation_x": {
-    "unicode": "1F5D9",
+    "unicode": "1f5d9",
     "unicode_alternates": [],
     "name": "cancellation x",
     "shortname": ":cancellation_x:",
@@ -15032,7 +15032,7 @@
     ]
   },
   "arrows_clockwise": {
-    "unicode": "1F503",
+    "unicode": "1f503",
     "unicode_alternates": [],
     "name": "clockwise downwards and upwards open circle arrows",
     "shortname": ":arrows_clockwise:",
@@ -15045,7 +15045,7 @@
     ]
   },
   "clockwise_arrows": {
-    "unicode": "1F5D8",
+    "unicode": "1f5d8",
     "unicode_alternates": [],
     "name": "clockwise right and left semicircle arrows",
     "shortname": ":clockwise_arrows:",
@@ -15074,7 +15074,7 @@
     ]
   },
   "copyright": {
-    "unicode": "00A9",
+    "unicode": "00a9",
     "unicode_alternates": [],
     "name": "copyright sign",
     "shortname": ":copyright:",
@@ -15088,7 +15088,7 @@
     ]
   },
   "registered": {
-    "unicode": "00AE",
+    "unicode": "00ae",
     "unicode_alternates": [],
     "name": "registered sign",
     "shortname": ":registered:",
@@ -15102,7 +15102,7 @@
     ]
   },
   "currency_exchange": {
-    "unicode": "1F4B1",
+    "unicode": "1f4b1",
     "unicode_alternates": [],
     "name": "currency exchange",
     "shortname": ":currency_exchange:",
@@ -15117,7 +15117,7 @@
     ]
   },
   "heavy_dollar_sign": {
-    "unicode": "1F4B2",
+    "unicode": "1f4b2",
     "unicode_alternates": [],
     "name": "heavy dollar sign",
     "shortname": ":heavy_dollar_sign:",
@@ -15136,7 +15136,7 @@
     ]
   },
   "curly_loop": {
-    "unicode": "27B0",
+    "unicode": "27b0",
     "unicode_alternates": [],
     "name": "curly loop",
     "shortname": ":curly_loop:",
@@ -15149,7 +15149,7 @@
     ]
   },
   "loop": {
-    "unicode": "27BF",
+    "unicode": "27bf",
     "unicode_alternates": [],
     "name": "double curly loop",
     "shortname": ":loop:",
@@ -15162,7 +15162,7 @@
     ]
   },
   "part_alternation_mark": {
-    "unicode": "303D",
+    "unicode": "303d",
     "unicode_alternates": [
       "303D-FE0F"
     ],
@@ -15242,7 +15242,7 @@
     ]
   },
   "bangbang": {
-    "unicode": "203C",
+    "unicode": "203c",
     "unicode_alternates": [
       "203C-FE0F"
     ],
@@ -15276,7 +15276,7 @@
     ]
   },
   "triangle_round": {
-    "unicode": "1F6C6",
+    "unicode": "1f6c6",
     "unicode_alternates": [],
     "name": "triangle with rounded corners",
     "shortname": ":triangle_round:",
@@ -15293,7 +15293,7 @@
     ]
   },
   "x": {
-    "unicode": "274C",
+    "unicode": "274c",
     "unicode_alternates": [],
     "name": "cross mark",
     "shortname": ":x:",
@@ -15310,7 +15310,7 @@
     ]
   },
   "o": {
-    "unicode": "2B55",
+    "unicode": "2b55",
     "unicode_alternates": [
       "2B55-FE0F"
     ],
@@ -15326,7 +15326,7 @@
     ]
   },
   "100": {
-    "unicode": "1F4AF",
+    "unicode": "1f4af",
     "unicode_alternates": [],
     "name": "hundred points symbol",
     "shortname": ":100:",
@@ -15350,7 +15350,7 @@
     ]
   },
   "end": {
-    "unicode": "1F51A",
+    "unicode": "1f51a",
     "unicode_alternates": [],
     "name": "end with leftwards arrow above",
     "shortname": ":end:",
@@ -15363,7 +15363,7 @@
     ]
   },
   "back": {
-    "unicode": "1F519",
+    "unicode": "1f519",
     "unicode_alternates": [],
     "name": "back with leftwards arrow above",
     "shortname": ":back:",
@@ -15376,7 +15376,7 @@
     ]
   },
   "on": {
-    "unicode": "1F51B",
+    "unicode": "1f51b",
     "unicode_alternates": [],
     "name": "on with exclamation mark with left right arrow abo",
     "shortname": ":on:",
@@ -15389,7 +15389,7 @@
     ]
   },
   "top": {
-    "unicode": "1F51D",
+    "unicode": "1f51d",
     "unicode_alternates": [],
     "name": "top with upwards arrow above",
     "shortname": ":top:",
@@ -15402,7 +15402,7 @@
     ]
   },
   "soon": {
-    "unicode": "1F51C",
+    "unicode": "1f51c",
     "unicode_alternates": [],
     "name": "soon with rightwards arrow above",
     "shortname": ":soon:",
@@ -15415,7 +15415,7 @@
     ]
   },
   "cyclone": {
-    "unicode": "1F300",
+    "unicode": "1f300",
     "unicode_alternates": [],
     "name": "cyclone",
     "shortname": ":cyclone:",
@@ -15435,7 +15435,7 @@
     ]
   },
   "m": {
-    "unicode": "24C2",
+    "unicode": "24c2",
     "unicode_alternates": [
       "24C2-FE0F"
     ],
@@ -15451,7 +15451,7 @@
     ]
   },
   "info": {
-    "unicode": "1F6C8",
+    "unicode": "1f6c8",
     "unicode_alternates": [],
     "name": "circled information source",
     "shortname": ":info:",
@@ -15466,7 +15466,7 @@
     ]
   },
   "ophiuchus": {
-    "unicode": "26CE",
+    "unicode": "26ce",
     "unicode_alternates": [],
     "name": "ophiuchus",
     "shortname": ":ophiuchus:",
@@ -15488,7 +15488,7 @@
     ]
   },
   "six_pointed_star": {
-    "unicode": "1F52F",
+    "unicode": "1f52f",
     "unicode_alternates": [],
     "name": "six pointed star with middle dot",
     "shortname": ":six_pointed_star:",
@@ -15501,7 +15501,7 @@
     ]
   },
   "beginner": {
-    "unicode": "1F530",
+    "unicode": "1f530",
     "unicode_alternates": [],
     "name": "japanese symbol for beginner",
     "shortname": ":beginner:",
@@ -15515,7 +15515,7 @@
     ]
   },
   "mood_lightning": {
-    "unicode": "1F5F2",
+    "unicode": "1f5f2",
     "unicode_alternates": [],
     "name": "lightning mood",
     "shortname": ":mood_lightning:",
@@ -15532,7 +15532,7 @@
     ]
   },
   "trident": {
-    "unicode": "1F531",
+    "unicode": "1f531",
     "unicode_alternates": [],
     "name": "trident emblem",
     "shortname": ":trident:",
@@ -15548,7 +15548,7 @@
     ]
   },
   "warning": {
-    "unicode": "26A0",
+    "unicode": "26a0",
     "unicode_alternates": [
       "26A0-FE0F"
     ],
@@ -15581,7 +15581,7 @@
     ]
   },
   "rosette": {
-    "unicode": "1F3F5",
+    "unicode": "1f3f5",
     "unicode_alternates": [],
     "name": "rosette",
     "shortname": ":rosette:",
@@ -15594,7 +15594,7 @@
     ]
   },
   "rosette_black": {
-    "unicode": "1F3F6",
+    "unicode": "1f3f6",
     "unicode_alternates": [],
     "name": "black rosette",
     "shortname": ":rosette_black:",
@@ -15607,7 +15607,7 @@
     ]
   },
   "recycle": {
-    "unicode": "267B",
+    "unicode": "267b",
     "unicode_alternates": [
       "267B-FE0F"
     ],
@@ -15625,7 +15625,7 @@
     ]
   },
   "anger": {
-    "unicode": "1F4A2",
+    "unicode": "1f4a2",
     "unicode_alternates": [],
     "name": "anger symbol",
     "shortname": ":anger:",
@@ -15639,7 +15639,7 @@
     ]
   },
   "diamond_shape_with_a_dot_inside": {
-    "unicode": "1F4A0",
+    "unicode": "1f4a0",
     "unicode_alternates": [],
     "name": "diamond shape with a dot inside",
     "shortname": ":diamond_shape_with_a_dot_inside:",
@@ -15737,7 +15737,7 @@
     ]
   },
   "light_check_mark": {
-    "unicode": "1F5F8",
+    "unicode": "1f5f8",
     "unicode_alternates": [],
     "name": "light check mark",
     "shortname": ":light_check_mark:",
@@ -15752,7 +15752,7 @@
     ]
   },
   "ballot_box_check": {
-    "unicode": "1F5F9",
+    "unicode": "1f5f9",
     "unicode_alternates": [],
     "name": "ballot box with bold check",
     "shortname": ":ballot_box_check:",
@@ -15768,7 +15768,7 @@
     ]
   },
   "ballot_x": {
-    "unicode": "1F5F4",
+    "unicode": "1f5f4",
     "unicode_alternates": [],
     "name": "ballot script x",
     "shortname": ":ballot_x:",
@@ -15784,7 +15784,7 @@
     ]
   },
   "ballot_box_x": {
-    "unicode": "1F5F5",
+    "unicode": "1f5f5",
     "unicode_alternates": [],
     "name": "ballot box with script x",
     "shortname": ":ballot_box_x:",
@@ -15800,7 +15800,7 @@
     ]
   },
   "white_circle": {
-    "unicode": "26AA",
+    "unicode": "26aa",
     "unicode_alternates": [
       "26AA-FE0F"
     ],
@@ -15815,7 +15815,7 @@
     ]
   },
   "black_circle": {
-    "unicode": "26AB",
+    "unicode": "26ab",
     "unicode_alternates": [
       "26AB-FE0F"
     ],
@@ -15830,7 +15830,7 @@
     ]
   },
   "radio_button": {
-    "unicode": "1F518",
+    "unicode": "1f518",
     "unicode_alternates": [],
     "name": "radio button",
     "shortname": ":radio_button:",
@@ -15843,7 +15843,7 @@
     ]
   },
   "red_circle": {
-    "unicode": "1F534",
+    "unicode": "1f534",
     "unicode_alternates": [],
     "name": "large red circle",
     "shortname": ":red_circle:",
@@ -15856,7 +15856,7 @@
     ]
   },
   "large_blue_circle": {
-    "unicode": "1F535",
+    "unicode": "1f535",
     "unicode_alternates": [],
     "name": "large blue circle",
     "shortname": ":large_blue_circle:",
@@ -15869,7 +15869,7 @@
     ]
   },
   "small_red_triangle": {
-    "unicode": "1F53A",
+    "unicode": "1f53a",
     "unicode_alternates": [],
     "name": "up-pointing red triangle",
     "shortname": ":small_red_triangle:",
@@ -15882,7 +15882,7 @@
     ]
   },
   "small_red_triangle_down": {
-    "unicode": "1F53B",
+    "unicode": "1f53b",
     "unicode_alternates": [],
     "name": "down-pointing red triangle",
     "shortname": ":small_red_triangle_down:",
@@ -15895,7 +15895,7 @@
     ]
   },
   "small_orange_diamond": {
-    "unicode": "1F538",
+    "unicode": "1f538",
     "unicode_alternates": [],
     "name": "small orange diamond",
     "shortname": ":small_orange_diamond:",
@@ -15908,7 +15908,7 @@
     ]
   },
   "small_blue_diamond": {
-    "unicode": "1F539",
+    "unicode": "1f539",
     "unicode_alternates": [],
     "name": "small blue diamond",
     "shortname": ":small_blue_diamond:",
@@ -15921,7 +15921,7 @@
     ]
   },
   "large_orange_diamond": {
-    "unicode": "1F536",
+    "unicode": "1f536",
     "unicode_alternates": [],
     "name": "large orange diamond",
     "shortname": ":large_orange_diamond:",
@@ -15934,7 +15934,7 @@
     ]
   },
   "large_blue_diamond": {
-    "unicode": "1F537",
+    "unicode": "1f537",
     "unicode_alternates": [],
     "name": "large blue diamond",
     "shortname": ":large_blue_diamond:",
@@ -15947,7 +15947,7 @@
     ]
   },
   "black_small_square": {
-    "unicode": "25AA",
+    "unicode": "25aa",
     "unicode_alternates": [
       "25AA-FE0F"
     ],
@@ -15962,7 +15962,7 @@
     ]
   },
   "white_small_square": {
-    "unicode": "25AB",
+    "unicode": "25ab",
     "unicode_alternates": [
       "25AB-FE0F"
     ],
@@ -15977,7 +15977,7 @@
     ]
   },
   "black_large_square": {
-    "unicode": "2B1B",
+    "unicode": "2b1b",
     "unicode_alternates": [
       "2B1B-FE0F"
     ],
@@ -15992,7 +15992,7 @@
     ]
   },
   "white_large_square": {
-    "unicode": "2B1C",
+    "unicode": "2b1c",
     "unicode_alternates": [
       "2B1C-FE0F"
     ],
@@ -16007,7 +16007,7 @@
     ]
   },
   "black_medium_square": {
-    "unicode": "25FC",
+    "unicode": "25fc",
     "unicode_alternates": [
       "25FC-FE0F"
     ],
@@ -16022,7 +16022,7 @@
     ]
   },
   "white_medium_square": {
-    "unicode": "25FB",
+    "unicode": "25fb",
     "unicode_alternates": [
       "25FB-FE0F"
     ],
@@ -16037,7 +16037,7 @@
     ]
   },
   "black_medium_small_square": {
-    "unicode": "25FE",
+    "unicode": "25fe",
     "unicode_alternates": [
       "25FE-FE0F"
     ],
@@ -16052,7 +16052,7 @@
     ]
   },
   "white_medium_small_square": {
-    "unicode": "25FD",
+    "unicode": "25fd",
     "unicode_alternates": [
       "25FD-FE0F"
     ],
@@ -16067,7 +16067,7 @@
     ]
   },
   "black_square_button": {
-    "unicode": "1F532",
+    "unicode": "1f532",
     "unicode_alternates": [],
     "name": "black square button",
     "shortname": ":black_square_button:",
@@ -16080,7 +16080,7 @@
     ]
   },
   "white_square_button": {
-    "unicode": "1F533",
+    "unicode": "1f533",
     "unicode_alternates": [],
     "name": "white square button",
     "shortname": ":white_square_button:",
@@ -16093,7 +16093,7 @@
     ]
   },
   "clock1": {
-    "unicode": "1F550",
+    "unicode": "1f550",
     "unicode_alternates": [],
     "name": "clock face one oclock",
     "shortname": ":clock1:",
@@ -16106,7 +16106,7 @@
     ]
   },
   "clock2": {
-    "unicode": "1F551",
+    "unicode": "1f551",
     "unicode_alternates": [],
     "name": "clock face two oclock",
     "shortname": ":clock2:",
@@ -16119,7 +16119,7 @@
     ]
   },
   "clock3": {
-    "unicode": "1F552",
+    "unicode": "1f552",
     "unicode_alternates": [],
     "name": "clock face three oclock",
     "shortname": ":clock3:",
@@ -16132,7 +16132,7 @@
     ]
   },
   "clock4": {
-    "unicode": "1F553",
+    "unicode": "1f553",
     "unicode_alternates": [],
     "name": "clock face four oclock",
     "shortname": ":clock4:",
@@ -16145,7 +16145,7 @@
     ]
   },
   "clock5": {
-    "unicode": "1F554",
+    "unicode": "1f554",
     "unicode_alternates": [],
     "name": "clock face five oclock",
     "shortname": ":clock5:",
@@ -16158,7 +16158,7 @@
     ]
   },
   "clock6": {
-    "unicode": "1F555",
+    "unicode": "1f555",
     "unicode_alternates": [],
     "name": "clock face six oclock",
     "shortname": ":clock6:",
@@ -16171,7 +16171,7 @@
     ]
   },
   "clock7": {
-    "unicode": "1F556",
+    "unicode": "1f556",
     "unicode_alternates": [],
     "name": "clock face seven oclock",
     "shortname": ":clock7:",
@@ -16184,7 +16184,7 @@
     ]
   },
   "clock8": {
-    "unicode": "1F557",
+    "unicode": "1f557",
     "unicode_alternates": [],
     "name": "clock face eight oclock",
     "shortname": ":clock8:",
@@ -16197,7 +16197,7 @@
     ]
   },
   "clock9": {
-    "unicode": "1F558",
+    "unicode": "1f558",
     "unicode_alternates": [],
     "name": "clock face nine oclock",
     "shortname": ":clock9:",
@@ -16210,7 +16210,7 @@
     ]
   },
   "clock10": {
-    "unicode": "1F559",
+    "unicode": "1f559",
     "unicode_alternates": [],
     "name": "clock face ten oclock",
     "shortname": ":clock10:",
@@ -16223,7 +16223,7 @@
     ]
   },
   "clock11": {
-    "unicode": "1F55A",
+    "unicode": "1f55a",
     "unicode_alternates": [],
     "name": "clock face eleven oclock",
     "shortname": ":clock11:",
@@ -16236,7 +16236,7 @@
     ]
   },
   "clock12": {
-    "unicode": "1F55B",
+    "unicode": "1f55b",
     "unicode_alternates": [],
     "name": "clock face twelve oclock",
     "shortname": ":clock12:",
@@ -16249,7 +16249,7 @@
     ]
   },
   "clock130": {
-    "unicode": "1F55C",
+    "unicode": "1f55c",
     "unicode_alternates": [],
     "name": "clock face one-thirty",
     "shortname": ":clock130:",
@@ -16262,7 +16262,7 @@
     ]
   },
   "clock230": {
-    "unicode": "1F55D",
+    "unicode": "1f55d",
     "unicode_alternates": [],
     "name": "clock face two-thirty",
     "shortname": ":clock230:",
@@ -16275,7 +16275,7 @@
     ]
   },
   "clock330": {
-    "unicode": "1F55E",
+    "unicode": "1f55e",
     "unicode_alternates": [],
     "name": "clock face three-thirty",
     "shortname": ":clock330:",
@@ -16288,7 +16288,7 @@
     ]
   },
   "clock430": {
-    "unicode": "1F55F",
+    "unicode": "1f55f",
     "unicode_alternates": [],
     "name": "clock face four-thirty",
     "shortname": ":clock430:",
@@ -16301,7 +16301,7 @@
     ]
   },
   "clock530": {
-    "unicode": "1F560",
+    "unicode": "1f560",
     "unicode_alternates": [],
     "name": "clock face five-thirty",
     "shortname": ":clock530:",
@@ -16314,7 +16314,7 @@
     ]
   },
   "clock630": {
-    "unicode": "1F561",
+    "unicode": "1f561",
     "unicode_alternates": [],
     "name": "clock face six-thirty",
     "shortname": ":clock630:",
@@ -16327,7 +16327,7 @@
     ]
   },
   "clock730": {
-    "unicode": "1F562",
+    "unicode": "1f562",
     "unicode_alternates": [],
     "name": "clock face seven-thirty",
     "shortname": ":clock730:",
@@ -16340,7 +16340,7 @@
     ]
   },
   "clock830": {
-    "unicode": "1F563",
+    "unicode": "1f563",
     "unicode_alternates": [],
     "name": "clock face eight-thirty",
     "shortname": ":clock830:",
@@ -16353,7 +16353,7 @@
     ]
   },
   "clock930": {
-    "unicode": "1F564",
+    "unicode": "1f564",
     "unicode_alternates": [],
     "name": "clock face nine-thirty",
     "shortname": ":clock930:",
@@ -16366,7 +16366,7 @@
     ]
   },
   "clock1030": {
-    "unicode": "1F565",
+    "unicode": "1f565",
     "unicode_alternates": [],
     "name": "clock face ten-thirty",
     "shortname": ":clock1030:",
@@ -16379,7 +16379,7 @@
     ]
   },
   "clock1130": {
-    "unicode": "1F566",
+    "unicode": "1f566",
     "unicode_alternates": [],
     "name": "clock face eleven-thirty",
     "shortname": ":clock1130:",
@@ -16392,7 +16392,7 @@
     ]
   },
   "clock1230": {
-    "unicode": "1F567",
+    "unicode": "1f567",
     "unicode_alternates": [],
     "name": "clock face twelve-thirty",
     "shortname": ":clock1230:",
@@ -16405,7 +16405,7 @@
     ]
   },
   "railway_car": {
-    "unicode": "1F683",
+    "unicode": "1f683",
     "unicode_alternates": [],
     "name": "railway car",
     "shortname": ":railway_car:",
@@ -16423,7 +16423,7 @@
     ]
   },
   "mountain_railway": {
-    "unicode": "1F69E",
+    "unicode": "1f69e",
     "unicode_alternates": [],
     "name": "mountain railway",
     "shortname": ":mountain_railway:",
@@ -16440,7 +16440,7 @@
     ]
   },
   "steam_locomotive": {
-    "unicode": "1F682",
+    "unicode": "1f682",
     "unicode_alternates": [],
     "name": "steam locomotive",
     "shortname": ":steam_locomotive:",
@@ -16456,7 +16456,7 @@
     ]
   },
   "train_diesel": {
-    "unicode": "1F6F2",
+    "unicode": "1f6f2",
     "unicode_alternates": [],
     "name": "diesel locomotive",
     "shortname": ":train_diesel:",
@@ -16474,7 +16474,7 @@
     ]
   },
   "train": {
-    "unicode": "1F68B",
+    "unicode": "1f68b",
     "unicode_alternates": [],
     "name": "Tram Car",
     "shortname": ":train:",
@@ -16490,7 +16490,7 @@
     ]
   },
   "monorail": {
-    "unicode": "1F69D",
+    "unicode": "1f69d",
     "unicode_alternates": [],
     "name": "monorail",
     "shortname": ":monorail:",
@@ -16507,7 +16507,7 @@
     ]
   },
   "bullettrain_side": {
-    "unicode": "1F684",
+    "unicode": "1f684",
     "unicode_alternates": [],
     "name": "high-speed train",
     "shortname": ":bullettrain_side:",
@@ -16525,7 +16525,7 @@
     ]
   },
   "bullettrain_front": {
-    "unicode": "1F685",
+    "unicode": "1f685",
     "unicode_alternates": [],
     "name": "high-speed train with bullet nose",
     "shortname": ":bullettrain_front:",
@@ -16543,7 +16543,7 @@
     ]
   },
   "train2": {
-    "unicode": "1F686",
+    "unicode": "1f686",
     "unicode_alternates": [],
     "name": "train",
     "shortname": ":train2:",
@@ -16560,7 +16560,7 @@
     ]
   },
   "metro": {
-    "unicode": "1F687",
+    "unicode": "1f687",
     "unicode_alternates": [],
     "name": "metro",
     "shortname": ":metro:",
@@ -16580,7 +16580,7 @@
     ]
   },
   "light_rail": {
-    "unicode": "1F688",
+    "unicode": "1f688",
     "unicode_alternates": [],
     "name": "light rail",
     "shortname": ":light_rail:",
@@ -16595,7 +16595,7 @@
     ]
   },
   "station": {
-    "unicode": "1F689",
+    "unicode": "1f689",
     "unicode_alternates": [],
     "name": "station",
     "shortname": ":station:",
@@ -16612,7 +16612,7 @@
     ]
   },
   "tram": {
-    "unicode": "1F68A",
+    "unicode": "1f68a",
     "unicode_alternates": [],
     "name": "tram",
     "shortname": ":tram:",
@@ -16629,7 +16629,7 @@
     ]
   },
   "railway_track": {
-    "unicode": "1F6E4",
+    "unicode": "1f6e4",
     "unicode_alternates": [],
     "name": "railway track",
     "shortname": ":railway_track:",
@@ -16648,7 +16648,7 @@
     ]
   },
   "bus": {
-    "unicode": "1F68C",
+    "unicode": "1f68c",
     "unicode_alternates": [],
     "name": "bus",
     "shortname": ":bus:",
@@ -16666,7 +16666,7 @@
     ]
   },
   "oncoming_bus": {
-    "unicode": "1F68D",
+    "unicode": "1f68d",
     "unicode_alternates": [],
     "name": "oncoming bus",
     "shortname": ":oncoming_bus:",
@@ -16684,7 +16684,7 @@
     ]
   },
   "trolleybus": {
-    "unicode": "1F68E",
+    "unicode": "1f68e",
     "unicode_alternates": [],
     "name": "trolleybus",
     "shortname": ":trolleybus:",
@@ -16702,7 +16702,7 @@
     ]
   },
   "minibus": {
-    "unicode": "1F690",
+    "unicode": "1f690",
     "unicode_alternates": [],
     "name": "minibus",
     "shortname": ":minibus:",
@@ -16719,7 +16719,7 @@
     ]
   },
   "ambulance": {
-    "unicode": "1F691",
+    "unicode": "1f691",
     "unicode_alternates": [],
     "name": "ambulance",
     "shortname": ":ambulance:",
@@ -16737,7 +16737,7 @@
     ]
   },
   "fire_engine": {
-    "unicode": "1F692",
+    "unicode": "1f692",
     "unicode_alternates": [],
     "name": "fire engine",
     "shortname": ":fire_engine:",
@@ -16754,7 +16754,7 @@
     ]
   },
   "fire_engine_oncoming": {
-    "unicode": "1F6F1",
+    "unicode": "1f6f1",
     "unicode_alternates": [],
     "name": "oncoming fire engine",
     "shortname": ":fire_engine_oncoming:",
@@ -16773,7 +16773,7 @@
     ]
   },
   "police_car": {
-    "unicode": "1F693",
+    "unicode": "1f693",
     "unicode_alternates": [],
     "name": "police car",
     "shortname": ":police_car:",
@@ -16798,7 +16798,7 @@
     ]
   },
   "oncoming_police_car": {
-    "unicode": "1F694",
+    "unicode": "1f694",
     "unicode_alternates": [],
     "name": "oncoming police car",
     "shortname": ":oncoming_police_car:",
@@ -16819,7 +16819,7 @@
     ]
   },
   "rotating_light": {
-    "unicode": "1F6A8",
+    "unicode": "1f6a8",
     "unicode_alternates": [],
     "name": "police cars revolving light",
     "shortname": ":rotating_light:",
@@ -16837,7 +16837,7 @@
     ]
   },
   "taxi": {
-    "unicode": "1F695",
+    "unicode": "1f695",
     "unicode_alternates": [],
     "name": "taxi",
     "shortname": ":taxi:",
@@ -16858,7 +16858,7 @@
     ]
   },
   "oncoming_taxi": {
-    "unicode": "1F696",
+    "unicode": "1f696",
     "unicode_alternates": [],
     "name": "oncoming taxi",
     "shortname": ":oncoming_taxi:",
@@ -16878,7 +16878,7 @@
     ]
   },
   "red_car": {
-    "unicode": "1F697",
+    "unicode": "1f697",
     "unicode_alternates": [],
     "name": "automobile",
     "shortname": ":red_car:",
@@ -16894,7 +16894,7 @@
     ]
   },
   "oncoming_automobile": {
-    "unicode": "1F698",
+    "unicode": "1f698",
     "unicode_alternates": [],
     "name": "oncoming automobile",
     "shortname": ":oncoming_automobile:",
@@ -16912,7 +16912,7 @@
     ]
   },
   "blue_car": {
-    "unicode": "1F699",
+    "unicode": "1f699",
     "unicode_alternates": [],
     "name": "recreational vehicle",
     "shortname": ":blue_car:",
@@ -16929,7 +16929,7 @@
     ]
   },
   "truck": {
-    "unicode": "1F69A",
+    "unicode": "1f69a",
     "unicode_alternates": [],
     "name": "delivery truck",
     "shortname": ":truck:",
@@ -16945,7 +16945,7 @@
     ]
   },
   "articulated_lorry": {
-    "unicode": "1F69B",
+    "unicode": "1f69b",
     "unicode_alternates": [],
     "name": "articulated lorry",
     "shortname": ":articulated_lorry:",
@@ -16962,7 +16962,7 @@
     ]
   },
   "tractor": {
-    "unicode": "1F69C",
+    "unicode": "1f69c",
     "unicode_alternates": [],
     "name": "tractor",
     "shortname": ":tractor:",
@@ -16980,7 +16980,7 @@
     ]
   },
   "bike": {
-    "unicode": "1F6B2",
+    "unicode": "1f6b2",
     "unicode_alternates": [],
     "name": "bicycle",
     "shortname": ":bike:",
@@ -16998,7 +16998,7 @@
     ]
   },
   "motorway": {
-    "unicode": "1F6E3",
+    "unicode": "1f6e3",
     "unicode_alternates": [],
     "name": "motorway",
     "shortname": ":motorway:",
@@ -17015,7 +17015,7 @@
     ]
   },
   "busstop": {
-    "unicode": "1F68F",
+    "unicode": "1f68f",
     "unicode_alternates": [],
     "name": "bus stop",
     "shortname": ":busstop:",
@@ -17030,7 +17030,7 @@
     ]
   },
   "fuelpump": {
-    "unicode": "26FD",
+    "unicode": "26fd",
     "unicode_alternates": [
       "26FD-FE0F"
     ],
@@ -17048,7 +17048,7 @@
     ]
   },
   "construction": {
-    "unicode": "1F6A7",
+    "unicode": "1f6a7",
     "unicode_alternates": [],
     "name": "construction sign",
     "shortname": ":construction:",
@@ -17063,7 +17063,7 @@
     ]
   },
   "vertical_traffic_light": {
-    "unicode": "1F6A6",
+    "unicode": "1f6a6",
     "unicode_alternates": [],
     "name": "vertical traffic light",
     "shortname": ":vertical_traffic_light:",
@@ -17080,7 +17080,7 @@
     ]
   },
   "traffic_light": {
-    "unicode": "1F6A5",
+    "unicode": "1f6a5",
     "unicode_alternates": [],
     "name": "horizontal traffic light",
     "shortname": ":traffic_light:",
@@ -17097,7 +17097,7 @@
     ]
   },
   "rocket": {
-    "unicode": "1F680",
+    "unicode": "1f680",
     "unicode_alternates": [],
     "name": "rocket",
     "shortname": ":rocket:",
@@ -17116,7 +17116,7 @@
     ]
   },
   "helicopter": {
-    "unicode": "1F681",
+    "unicode": "1f681",
     "unicode_alternates": [],
     "name": "helicopter",
     "shortname": ":helicopter:",
@@ -17159,7 +17159,7 @@
     ]
   },
   "airplane_up": {
-    "unicode": "1F6E7",
+    "unicode": "1f6e7",
     "unicode_alternates": [],
     "name": "up-pointing airplane",
     "shortname": ":airplane_up:",
@@ -17175,7 +17175,7 @@
     ]
   },
   "airplane_small_up": {
-    "unicode": "1F6E8",
+    "unicode": "1f6e8",
     "unicode_alternates": [],
     "name": "up-pointing small airplane",
     "shortname": ":airplane_small_up:",
@@ -17191,7 +17191,7 @@
     ]
   },
   "jet_up": {
-    "unicode": "1F6E6",
+    "unicode": "1f6e6",
     "unicode_alternates": [],
     "name": "up-pointing military airplane",
     "shortname": ":jet_up:",
@@ -17206,7 +17206,7 @@
     ]
   },
   "airplane_northeast": {
-    "unicode": "1F6EA",
+    "unicode": "1f6ea",
     "unicode_alternates": [],
     "name": "northeast-pointing airplane",
     "shortname": ":airplane_northeast:",
@@ -17222,7 +17222,7 @@
     ]
   },
   "airplane_small": {
-    "unicode": "1F6E9",
+    "unicode": "1f6e9",
     "unicode_alternates": [],
     "name": "small airplane",
     "shortname": ":airplane_small:",
@@ -17248,7 +17248,7 @@
     ]
   },
   "airplane_departure": {
-    "unicode": "1F6EB",
+    "unicode": "1f6eb",
     "unicode_alternates": [],
     "name": "airplane departure",
     "shortname": ":airplane_departure:",
@@ -17273,7 +17273,7 @@
     ]
   },
   "airplane_arriving": {
-    "unicode": "1F6EC",
+    "unicode": "1f6ec",
     "unicode_alternates": [],
     "name": "airplane arriving",
     "shortname": ":airplane_arriving:",
@@ -17297,7 +17297,7 @@
     ]
   },
   "seat": {
-    "unicode": "1F4BA",
+    "unicode": "1f4ba",
     "unicode_alternates": [],
     "name": "seat",
     "shortname": ":seat:",
@@ -17334,7 +17334,7 @@
     ]
   },
   "ship": {
-    "unicode": "1F6A2",
+    "unicode": "1f6a2",
     "unicode_alternates": [],
     "name": "ship",
     "shortname": ":ship:",
@@ -17351,7 +17351,7 @@
     ]
   },
   "cruise_ship": {
-    "unicode": "1F6F3",
+    "unicode": "1f6f3",
     "unicode_alternates": [],
     "name": "passenger ship",
     "shortname": ":cruise_ship:",
@@ -17368,7 +17368,7 @@
     ]
   },
   "motorboat": {
-    "unicode": "1F6E5",
+    "unicode": "1f6e5",
     "unicode_alternates": [],
     "name": "motorboat",
     "shortname": ":motorboat:",
@@ -17385,7 +17385,7 @@
     ]
   },
   "speedboat": {
-    "unicode": "1F6A4",
+    "unicode": "1f6a4",
     "unicode_alternates": [],
     "name": "speedboat",
     "shortname": ":speedboat:",
@@ -17402,7 +17402,7 @@
     ]
   },
   "sailboat": {
-    "unicode": "26F5",
+    "unicode": "26f5",
     "unicode_alternates": [
       "26F5-FE0F"
     ],
@@ -17424,7 +17424,7 @@
     ]
   },
   "aerial_tramway": {
-    "unicode": "1F6A1",
+    "unicode": "1f6a1",
     "unicode_alternates": [],
     "name": "aerial tramway",
     "shortname": ":aerial_tramway:",
@@ -17441,7 +17441,7 @@
     ]
   },
   "mountain_cableway": {
-    "unicode": "1F6A0",
+    "unicode": "1f6a0",
     "unicode_alternates": [],
     "name": "mountain cableway",
     "shortname": ":mountain_cableway:",
@@ -17456,7 +17456,7 @@
     ]
   },
   "suspension_railway": {
-    "unicode": "1F69F",
+    "unicode": "1f69f",
     "unicode_alternates": [],
     "name": "suspension railway",
     "shortname": ":suspension_railway:",
@@ -17471,7 +17471,7 @@
     ]
   },
   "passport_control": {
-    "unicode": "1F6C2",
+    "unicode": "1f6c2",
     "unicode_alternates": [],
     "name": "passport control",
     "shortname": ":passport_control:",
@@ -17493,7 +17493,7 @@
     ]
   },
   "customs": {
-    "unicode": "1F6C3",
+    "unicode": "1f6c3",
     "unicode_alternates": [],
     "name": "customs",
     "shortname": ":customs:",
@@ -17515,7 +17515,7 @@
     ]
   },
   "baggage_claim": {
-    "unicode": "1F6C4",
+    "unicode": "1f6c4",
     "unicode_alternates": [],
     "name": "baggage claim",
     "shortname": ":baggage_claim:",
@@ -17534,7 +17534,7 @@
     ]
   },
   "left_luggage": {
-    "unicode": "1F6C5",
+    "unicode": "1f6c5",
     "unicode_alternates": [],
     "name": "left luggage",
     "shortname": ":left_luggage:",
@@ -17551,7 +17551,7 @@
     ]
   },
   "yen": {
-    "unicode": "1F4B4",
+    "unicode": "1f4b4",
     "unicode_alternates": [],
     "name": "banknote with yen sign",
     "shortname": ":yen:",
@@ -17571,7 +17571,7 @@
     ]
   },
   "euro": {
-    "unicode": "1F4B6",
+    "unicode": "1f4b6",
     "unicode_alternates": [],
     "name": "banknote with euro sign",
     "shortname": ":euro:",
@@ -17590,7 +17590,7 @@
     ]
   },
   "pound": {
-    "unicode": "1F4B7",
+    "unicode": "1f4b7",
     "unicode_alternates": [],
     "name": "banknote with pound sign",
     "shortname": ":pound:",
@@ -17612,7 +17612,7 @@
     ]
   },
   "dollar": {
-    "unicode": "1F4B5",
+    "unicode": "1f4b5",
     "unicode_alternates": [],
     "name": "banknote with dollar sign",
     "shortname": ":dollar:",
@@ -17632,7 +17632,7 @@
     ]
   },
   "bellhop": {
-    "unicode": "1F6CE",
+    "unicode": "1f6ce",
     "unicode_alternates": [],
     "name": "bellhop bell",
     "shortname": ":bellhop:",
@@ -17649,7 +17649,7 @@
     ]
   },
   "bed": {
-    "unicode": "1F6CF",
+    "unicode": "1f6cf",
     "unicode_alternates": [],
     "name": "bed",
     "shortname": ":bed:",
@@ -17668,7 +17668,7 @@
     ]
   },
   "couch": {
-    "unicode": "1F6CB",
+    "unicode": "1f6cb",
     "unicode_alternates": [],
     "name": "couch and lamp",
     "shortname": ":couch:",
@@ -17690,7 +17690,7 @@
     ]
   },
   "fork_knife_plate": {
-    "unicode": "1F37D",
+    "unicode": "1f37d",
     "unicode_alternates": [],
     "name": "fork and knife with plate",
     "shortname": ":fork_knife_plate:",
@@ -17711,7 +17711,7 @@
     ]
   },
   "shopping_bags": {
-    "unicode": "1F6CD",
+    "unicode": "1f6cd",
     "unicode_alternates": [],
     "name": "shopping bags",
     "shortname": ":shopping_bags:",
@@ -17728,7 +17728,7 @@
     ]
   },
   "statue_of_liberty": {
-    "unicode": "1F5FD",
+    "unicode": "1f5fd",
     "unicode_alternates": [],
     "name": "statue of liberty",
     "shortname": ":statue_of_liberty:",
@@ -17743,7 +17743,7 @@
     ]
   },
   "moyai": {
-    "unicode": "1F5FF",
+    "unicode": "1f5ff",
     "unicode_alternates": [],
     "name": "moyai",
     "shortname": ":moyai:",
@@ -17757,7 +17757,7 @@
     ]
   },
   "foggy": {
-    "unicode": "1F301",
+    "unicode": "1f301",
     "unicode_alternates": [],
     "name": "foggy",
     "shortname": ":foggy:",
@@ -17773,7 +17773,7 @@
     ]
   },
   "tokyo_tower": {
-    "unicode": "1F5FC",
+    "unicode": "1f5fc",
     "unicode_alternates": [],
     "name": "tokyo tower",
     "shortname": ":tokyo_tower:",
@@ -17786,7 +17786,7 @@
     ]
   },
   "fountain": {
-    "unicode": "26F2",
+    "unicode": "26f2",
     "unicode_alternates": [
       "26F2-FE0F"
     ],
@@ -17806,7 +17806,7 @@
     ]
   },
   "european_castle": {
-    "unicode": "1F3F0",
+    "unicode": "1f3f0",
     "unicode_alternates": [],
     "name": "european castle",
     "shortname": ":european_castle:",
@@ -17836,7 +17836,7 @@
     ]
   },
   "japanese_castle": {
-    "unicode": "1F3EF",
+    "unicode": "1f3ef",
     "unicode_alternates": [],
     "name": "japanese castle",
     "shortname": ":japanese_castle:",
@@ -17855,7 +17855,7 @@
     ]
   },
   "classical_building": {
-    "unicode": "1F3DB",
+    "unicode": "1f3db",
     "unicode_alternates": [],
     "name": "classical building",
     "shortname": ":classical_building:",
@@ -17872,7 +17872,7 @@
     ]
   },
   "stadium": {
-    "unicode": "1F3DF",
+    "unicode": "1f3df",
     "unicode_alternates": [],
     "name": "stadium",
     "shortname": ":stadium:",
@@ -17889,7 +17889,7 @@
     ]
   },
   "mountain_snow": {
-    "unicode": "1F3D4",
+    "unicode": "1f3d4",
     "unicode_alternates": [],
     "name": "snow capped mountain",
     "shortname": ":mountain_snow:",
@@ -17907,7 +17907,7 @@
     ]
   },
   "camping": {
-    "unicode": "1F3D5",
+    "unicode": "1f3d5",
     "unicode_alternates": [],
     "name": "camping",
     "shortname": ":camping:",
@@ -17924,7 +17924,7 @@
     ]
   },
   "beach": {
-    "unicode": "1F3D6",
+    "unicode": "1f3d6",
     "unicode_alternates": [],
     "name": "beach with umbrella",
     "shortname": ":beach:",
@@ -17946,7 +17946,7 @@
     ]
   },
   "desert": {
-    "unicode": "1F3DC",
+    "unicode": "1f3dc",
     "unicode_alternates": [],
     "name": "desert",
     "shortname": ":desert:",
@@ -17964,7 +17964,7 @@
     ]
   },
   "island": {
-    "unicode": "1F3DD",
+    "unicode": "1f3dd",
     "unicode_alternates": [],
     "name": "desert island",
     "shortname": ":island:",
@@ -17981,7 +17981,7 @@
     ]
   },
   "park": {
-    "unicode": "1F3DE",
+    "unicode": "1f3de",
     "unicode_alternates": [],
     "name": "national park",
     "shortname": ":park:",
@@ -18001,7 +18001,7 @@
     ]
   },
   "cityscape": {
-    "unicode": "1F3D9",
+    "unicode": "1f3d9",
     "unicode_alternates": [],
     "name": "cityscape",
     "shortname": ":cityscape:",
@@ -18019,7 +18019,7 @@
     ]
   },
   "city_sunset": {
-    "unicode": "1F307",
+    "unicode": "1f307",
     "unicode_alternates": [],
     "name": "sunset over buildings",
     "shortname": ":city_sunset:",
@@ -18041,7 +18041,7 @@
     ]
   },
   "city_dusk": {
-    "unicode": "1F306",
+    "unicode": "1f306",
     "unicode_alternates": [],
     "name": "cityscape at dusk",
     "shortname": ":city_dusk:",
@@ -18061,7 +18061,7 @@
     ]
   },
   "night_with_stars": {
-    "unicode": "1F303",
+    "unicode": "1f303",
     "unicode_alternates": [],
     "name": "night with stars",
     "shortname": ":night_with_stars:",
@@ -18078,7 +18078,7 @@
     ]
   },
   "bridge_at_night": {
-    "unicode": "1F309",
+    "unicode": "1f309",
     "unicode_alternates": [],
     "name": "bridge at night",
     "shortname": ":bridge_at_night:",
@@ -18096,7 +18096,7 @@
     ]
   },
   "house": {
-    "unicode": "1F3E0",
+    "unicode": "1f3e0",
     "unicode_alternates": [],
     "name": "house building",
     "shortname": ":house:",
@@ -18115,7 +18115,7 @@
     ]
   },
   "homes": {
-    "unicode": "1F3D8",
+    "unicode": "1f3d8",
     "unicode_alternates": [],
     "name": "house buildings",
     "shortname": ":homes:",
@@ -18136,7 +18136,7 @@
     ]
   },
   "house_with_garden": {
-    "unicode": "1F3E1",
+    "unicode": "1f3e1",
     "unicode_alternates": [],
     "name": "house with garden",
     "shortname": ":house_with_garden:",
@@ -18158,7 +18158,7 @@
     ]
   },
   "house_abandoned": {
-    "unicode": "1F3DA",
+    "unicode": "1f3da",
     "unicode_alternates": [],
     "name": "derelict house building",
     "shortname": ":house_abandoned:",
@@ -18184,7 +18184,7 @@
     ]
   },
   "contruction_site": {
-    "unicode": "1F3D7",
+    "unicode": "1f3d7",
     "unicode_alternates": [],
     "name": "building construction",
     "shortname": ":contruction_site:",
@@ -18200,7 +18200,7 @@
     ]
   },
   "office": {
-    "unicode": "1F3E2",
+    "unicode": "1f3e2",
     "unicode_alternates": [],
     "name": "office building",
     "shortname": ":office:",
@@ -18215,7 +18215,7 @@
     ]
   },
   "department_store": {
-    "unicode": "1F3EC",
+    "unicode": "1f3ec",
     "unicode_alternates": [],
     "name": "department store",
     "shortname": ":department_store:",
@@ -18233,7 +18233,7 @@
     ]
   },
   "factory": {
-    "unicode": "1F3ED",
+    "unicode": "1f3ed",
     "unicode_alternates": [],
     "name": "factory",
     "shortname": ":factory:",
@@ -18248,7 +18248,7 @@
     ]
   },
   "post_office": {
-    "unicode": "1F3E3",
+    "unicode": "1f3e3",
     "unicode_alternates": [],
     "name": "japanese post office",
     "shortname": ":post_office:",
@@ -18265,7 +18265,7 @@
     ]
   },
   "european_post_office": {
-    "unicode": "1F3E4",
+    "unicode": "1f3e4",
     "unicode_alternates": [],
     "name": "european post office",
     "shortname": ":european_post_office:",
@@ -18282,7 +18282,7 @@
     ]
   },
   "hospital": {
-    "unicode": "1F3E5",
+    "unicode": "1f3e5",
     "unicode_alternates": [],
     "name": "hospital",
     "shortname": ":hospital:",
@@ -18298,7 +18298,7 @@
     ]
   },
   "bank": {
-    "unicode": "1F3E6",
+    "unicode": "1f3e6",
     "unicode_alternates": [],
     "name": "bank",
     "shortname": ":bank:",
@@ -18314,7 +18314,7 @@
     ]
   },
   "hotel": {
-    "unicode": "1F3E8",
+    "unicode": "1f3e8",
     "unicode_alternates": [],
     "name": "hotel",
     "shortname": ":hotel:",
@@ -18331,7 +18331,7 @@
     ]
   },
   "love_hotel": {
-    "unicode": "1F3E9",
+    "unicode": "1f3e9",
     "unicode_alternates": [],
     "name": "love hotel",
     "shortname": ":love_hotel:",
@@ -18353,7 +18353,7 @@
     ]
   },
   "wedding": {
-    "unicode": "1F492",
+    "unicode": "1f492",
     "unicode_alternates": [],
     "name": "wedding",
     "shortname": ":wedding:",
@@ -18373,7 +18373,7 @@
     ]
   },
   "church": {
-    "unicode": "26EA",
+    "unicode": "26ea",
     "unicode_alternates": [
       "26EA-FE0F"
     ],
@@ -18390,7 +18390,7 @@
     ]
   },
   "convenience_store": {
-    "unicode": "1F3EA",
+    "unicode": "1f3ea",
     "unicode_alternates": [],
     "name": "convenience store",
     "shortname": ":convenience_store:",
@@ -18406,7 +18406,7 @@
     ]
   },
   "school": {
-    "unicode": "1F3EB",
+    "unicode": "1f3eb",
     "unicode_alternates": [],
     "name": "school",
     "shortname": ":school:",
@@ -18426,7 +18426,7 @@
     ]
   },
   "map": {
-    "unicode": "1F5FA",
+    "unicode": "1f5fa",
     "unicode_alternates": [],
     "name": "world map",
     "shortname": ":map:",
@@ -18443,7 +18443,7 @@
     ]
   },
   "flag_au": {
-    "unicode": "1F1E6-1F1FA",
+    "unicode": "1f1e6-1F1FA",
     "unicode_alternates": [],
     "name": "australia",
     "shortname": ":flag_au:",
@@ -18460,7 +18460,7 @@
     ]
   },
   "flag_at": {
-    "unicode": "1F1E6-1F1F9",
+    "unicode": "1f1e6-1F1F9",
     "unicode_alternates": [],
     "name": "austria",
     "shortname": ":flag_at:",
@@ -18479,7 +18479,7 @@
     ]
   },
   "flag_be": {
-    "unicode": "1F1E7-1F1EA",
+    "unicode": "1f1e7-1F1EA",
     "unicode_alternates": [],
     "name": "belgium",
     "shortname": ":flag_be:",
@@ -18498,7 +18498,7 @@
     ]
   },
   "flag_br": {
-    "unicode": "1F1E7-1F1F7",
+    "unicode": "1f1e7-1F1F7",
     "unicode_alternates": [],
     "name": "brazil",
     "shortname": ":flag_br:",
@@ -18516,7 +18516,7 @@
     ]
   },
   "flag_ca": {
-    "unicode": "1F1E8-1F1E6",
+    "unicode": "1f1e8-1F1E6",
     "unicode_alternates": [],
     "name": "canada",
     "shortname": ":flag_ca:",
@@ -18533,7 +18533,7 @@
     ]
   },
   "flag_cl": {
-    "unicode": "1F1E8-1F1F1",
+    "unicode": "1f1e8-1F1F1",
     "unicode_alternates": [],
     "name": "chile",
     "shortname": ":flag_cl:",
@@ -18550,7 +18550,7 @@
     ]
   },
   "flag_cn": {
-    "unicode": "1F1E8-1F1F3",
+    "unicode": "1f1e8-1F1F3",
     "unicode_alternates": [],
     "name": "china",
     "shortname": ":flag_cn:",
@@ -18570,7 +18570,7 @@
     ]
   },
   "flag_co": {
-    "unicode": "1F1E8-1F1F4",
+    "unicode": "1f1e8-1F1F4",
     "unicode_alternates": [],
     "name": "colombia",
     "shortname": ":flag_co:",
@@ -18587,7 +18587,7 @@
     ]
   },
   "flag_dk": {
-    "unicode": "1F1E9-1F1F0",
+    "unicode": "1f1e9-1F1F0",
     "unicode_alternates": [],
     "name": "denmark",
     "shortname": ":flag_dk:",
@@ -18605,7 +18605,7 @@
     ]
   },
   "flag_fi": {
-    "unicode": "1F1EB-1F1EE",
+    "unicode": "1f1eb-1F1EE",
     "unicode_alternates": [],
     "name": "finland",
     "shortname": ":flag_fi:",
@@ -18623,7 +18623,7 @@
     ]
   },
   "flag_fr": {
-    "unicode": "1F1EB-1F1F7",
+    "unicode": "1f1eb-1F1F7",
     "unicode_alternates": [],
     "name": "france",
     "shortname": ":flag_fr:",
@@ -18641,7 +18641,7 @@
     ]
   },
   "flag_de": {
-    "unicode": "1F1E9-1F1EA",
+    "unicode": "1f1e9-1F1EA",
     "unicode_alternates": [],
     "name": "germany",
     "shortname": ":flag_de:",
@@ -18660,7 +18660,7 @@
     ]
   },
   "flag_hk": {
-    "unicode": "1F1ED-1F1F0",
+    "unicode": "1f1ed-1F1F0",
     "unicode_alternates": [],
     "name": "hong kong",
     "shortname": ":flag_hk:",
@@ -18678,7 +18678,7 @@
     ]
   },
   "flag_in": {
-    "unicode": "1F1EE-1F1F3",
+    "unicode": "1f1ee-1F1F3",
     "unicode_alternates": [],
     "name": "india",
     "shortname": ":flag_in:",
@@ -18696,7 +18696,7 @@
     ]
   },
   "flag_id": {
-    "unicode": "1F1EE-1F1E9",
+    "unicode": "1f1ee-1F1E9",
     "unicode_alternates": [],
     "name": "indonesia",
     "shortname": ":flag_id:",
@@ -18713,7 +18713,7 @@
     ]
   },
   "flag_ie": {
-    "unicode": "1F1EE-1F1EA",
+    "unicode": "1f1ee-1F1EA",
     "unicode_alternates": [],
     "name": "ireland",
     "shortname": ":flag_ie:",
@@ -18732,7 +18732,7 @@
     ]
   },
   "flag_il": {
-    "unicode": "1F1EE-1F1F1",
+    "unicode": "1f1ee-1F1F1",
     "unicode_alternates": [],
     "name": "israel",
     "shortname": ":flag_il:",
@@ -18751,7 +18751,7 @@
     ]
   },
   "flag_it": {
-    "unicode": "1F1EE-1F1F9",
+    "unicode": "1f1ee-1F1F9",
     "unicode_alternates": [],
     "name": "italy",
     "shortname": ":flag_it:",
@@ -18769,7 +18769,7 @@
     ]
   },
   "flag_jp": {
-    "unicode": "1F1EF-1F1F5",
+    "unicode": "1f1ef-1F1F5",
     "unicode_alternates": [],
     "name": "japan",
     "shortname": ":flag_jp:",
@@ -18787,7 +18787,7 @@
     ]
   },
   "flag_kr": {
-    "unicode": "1F1F0-1F1F7",
+    "unicode": "1f1f0-1F1F7",
     "unicode_alternates": [],
     "name": "korea",
     "shortname": ":flag_kr:",
@@ -18805,7 +18805,7 @@
     ]
   },
   "flag_mo": {
-    "unicode": "1F1F2-1F1F4",
+    "unicode": "1f1f2-1F1F4",
     "unicode_alternates": [],
     "name": "macau",
     "shortname": ":flag_mo:",
@@ -18823,7 +18823,7 @@
     ]
   },
   "flag_my": {
-    "unicode": "1F1F2-1F1FE",
+    "unicode": "1f1f2-1F1FE",
     "unicode_alternates": [],
     "name": "malaysia",
     "shortname": ":flag_my:",
@@ -18840,7 +18840,7 @@
     ]
   },
   "flag_mx": {
-    "unicode": "1F1F2-1F1FD",
+    "unicode": "1f1f2-1F1FD",
     "unicode_alternates": [],
     "name": "mexico",
     "shortname": ":flag_mx:",
@@ -18857,7 +18857,7 @@
     ]
   },
   "flag_nl": {
-    "unicode": "1F1F3-1F1F1",
+    "unicode": "1f1f3-1F1F1",
     "unicode_alternates": [],
     "name": "the netherlands",
     "shortname": ":flag_nl:",
@@ -18876,7 +18876,7 @@
     ]
   },
   "flag_nz": {
-    "unicode": "1F1F3-1F1FF",
+    "unicode": "1f1f3-1F1FF",
     "unicode_alternates": [],
     "name": "new zealand",
     "shortname": ":flag_nz:",
@@ -18894,7 +18894,7 @@
     ]
   },
   "flag_no": {
-    "unicode": "1F1F3-1F1F4",
+    "unicode": "1f1f3-1F1F4",
     "unicode_alternates": [],
     "name": "norway",
     "shortname": ":flag_no:",
@@ -18912,7 +18912,7 @@
     ]
   },
   "flag_ph": {
-    "unicode": "1F1F5-1F1ED",
+    "unicode": "1f1f5-1F1ED",
     "unicode_alternates": [],
     "name": "the philippines",
     "shortname": ":flag_ph:",
@@ -18930,7 +18930,7 @@
     ]
   },
   "flag_pl": {
-    "unicode": "1F1F5-1F1F1",
+    "unicode": "1f1f5-1F1F1",
     "unicode_alternates": [],
     "name": "poland",
     "shortname": ":flag_pl:",
@@ -18948,7 +18948,7 @@
     ]
   },
   "flag_pt": {
-    "unicode": "1F1F5-1F1F9",
+    "unicode": "1f1f5-1F1F9",
     "unicode_alternates": [],
     "name": "portugal",
     "shortname": ":flag_pt:",
@@ -18965,7 +18965,7 @@
     ]
   },
   "flag_pr": {
-    "unicode": "1F1F5-1F1F7",
+    "unicode": "1f1f5-1F1F7",
     "unicode_alternates": [],
     "name": "puerto rico",
     "shortname": ":flag_pr:",
@@ -18982,7 +18982,7 @@
     ]
   },
   "flag_ru": {
-    "unicode": "1F1F7-1F1FA",
+    "unicode": "1f1f7-1F1FA",
     "unicode_alternates": [],
     "name": "russia",
     "shortname": ":flag_ru:",
@@ -19000,7 +19000,7 @@
     ]
   },
   "flag_sa": {
-    "unicode": "1F1F8-1F1E6",
+    "unicode": "1f1f8-1F1E6",
     "unicode_alternates": [],
     "name": "saudi arabia",
     "shortname": ":flag_sa:",
@@ -19019,7 +19019,7 @@
     ]
   },
   "flag_sg": {
-    "unicode": "1F1F8-1F1EC",
+    "unicode": "1f1f8-1F1EC",
     "unicode_alternates": [],
     "name": "singapore",
     "shortname": ":flag_sg:",
@@ -19036,7 +19036,7 @@
     ]
   },
   "flag_za": {
-    "unicode": "1F1FF-1F1E6",
+    "unicode": "1f1ff-1F1E6",
     "unicode_alternates": [],
     "name": "south africa",
     "shortname": ":flag_za:",
@@ -19052,7 +19052,7 @@
     ]
   },
   "flag_es": {
-    "unicode": "1F1EA-1F1F8",
+    "unicode": "1f1ea-1F1F8",
     "unicode_alternates": [],
     "name": "spain",
     "shortname": ":flag_es:",
@@ -19071,7 +19071,7 @@
     ]
   },
   "flag_se": {
-    "unicode": "1F1F8-1F1EA",
+    "unicode": "1f1f8-1F1EA",
     "unicode_alternates": [],
     "name": "sweden",
     "shortname": ":flag_se:",
@@ -19089,7 +19089,7 @@
     ]
   },
   "flag_ch": {
-    "unicode": "1F1E8-1F1ED",
+    "unicode": "1f1e8-1F1ED",
     "unicode_alternates": [],
     "name": "switzerland",
     "shortname": ":flag_ch:",
@@ -19106,7 +19106,7 @@
     ]
   },
   "flag_tr": {
-    "unicode": "1F1F9-1F1F7",
+    "unicode": "1f1f9-1F1F7",
     "unicode_alternates": [],
     "name": "turkey",
     "shortname": ":flag_tr:",
@@ -19123,7 +19123,7 @@
     ]
   },
   "flag_gb": {
-    "unicode": "1F1EC-1F1E7",
+    "unicode": "1f1ec-1F1E7",
     "unicode_alternates": [],
     "name": "great britain",
     "shortname": ":flag_gb:",
@@ -19144,7 +19144,7 @@
     ]
   },
   "flag_us": {
-    "unicode": "1F1FA-1F1F8",
+    "unicode": "1f1fa-1F1F8",
     "unicode_alternates": [],
     "name": "united states",
     "shortname": ":flag_us:",
@@ -19166,7 +19166,7 @@
     ]
   },
   "flag_ae": {
-    "unicode": "1F1E6-1F1EA",
+    "unicode": "1f1e6-1F1EA",
     "unicode_alternates": [],
     "name": "the united arab emirates",
     "shortname": ":flag_ae:",
@@ -19183,7 +19183,7 @@
     ]
   },
   "flag_vn": {
-    "unicode": "1F1FB-1F1F3",
+    "unicode": "1f1fb-1F1F3",
     "unicode_alternates": [],
     "name": "vietnam",
     "shortname": ":flag_vn:",
@@ -19201,7 +19201,7 @@
     ]
   },
   "flag_af": {
-    "unicode": "1F1E6-1F1EB",
+    "unicode": "1f1e6-1F1EB",
     "unicode_alternates": [],
     "name": "afghanistan",
     "shortname": ":flag_af:",
@@ -19219,7 +19219,7 @@
     ]
   },
   "flag_al": {
-    "unicode": "1F1E6-1F1F1",
+    "unicode": "1f1e6-1F1F1",
     "unicode_alternates": [],
     "name": "albania",
     "shortname": ":flag_al:",
@@ -19237,7 +19237,7 @@
     ]
   },
   "flag_dz": {
-    "unicode": "1F1E9-1F1FF",
+    "unicode": "1f1e9-1F1FF",
     "unicode_alternates": [],
     "name": "algeria",
     "shortname": ":flag_dz:",
@@ -19256,7 +19256,7 @@
     ]
   },
   "flag_ad": {
-    "unicode": "1F1E6-1F1E9",
+    "unicode": "1f1e6-1F1E9",
     "unicode_alternates": [],
     "name": "andorra",
     "shortname": ":flag_ad:",
@@ -19273,7 +19273,7 @@
     ]
   },
   "flag_ao": {
-    "unicode": "1F1E6-1F1F4",
+    "unicode": "1f1e6-1F1F4",
     "unicode_alternates": [],
     "name": "angola",
     "shortname": ":flag_ao:",
@@ -19290,7 +19290,7 @@
     ]
   },
   "flag_ai": {
-    "unicode": "1F1E6-1F1EE",
+    "unicode": "1f1e6-1F1EE",
     "unicode_alternates": [],
     "name": "anguilla",
     "shortname": ":flag_ai:",
@@ -19307,7 +19307,7 @@
     ]
   },
   "flag_ag": {
-    "unicode": "1F1E6-1F1EC",
+    "unicode": "1f1e6-1F1EC",
     "unicode_alternates": [],
     "name": "antigua and barbuda",
     "shortname": ":flag_ag:",
@@ -19324,7 +19324,7 @@
     ]
   },
   "flag_ar": {
-    "unicode": "1F1E6-1F1F7",
+    "unicode": "1f1e6-1F1F7",
     "unicode_alternates": [],
     "name": "argentina",
     "shortname": ":flag_ar:",
@@ -19341,7 +19341,7 @@
     ]
   },
   "flag_am": {
-    "unicode": "1F1E6-1F1F2",
+    "unicode": "1f1e6-1F1F2",
     "unicode_alternates": [],
     "name": "armenia",
     "shortname": ":flag_am:",
@@ -19359,7 +19359,7 @@
     ]
   },
   "flag_aw": {
-    "unicode": "1F1E6-1F1FC",
+    "unicode": "1f1e6-1F1FC",
     "unicode_alternates": [],
     "name": "aruba",
     "shortname": ":flag_aw:",
@@ -19376,7 +19376,7 @@
     ]
   },
   "flag_ac": {
-    "unicode": "1F1E6-1F1E8",
+    "unicode": "1f1e6-1F1E8",
     "unicode_alternates": [],
     "name": "ascension",
     "shortname": ":flag_ac:",
@@ -19393,7 +19393,7 @@
     ]
   },
   "flag_az": {
-    "unicode": "1F1E6-1F1FF",
+    "unicode": "1f1e6-1F1FF",
     "unicode_alternates": [],
     "name": "azerbaijan",
     "shortname": ":flag_az:",
@@ -19411,7 +19411,7 @@
     ]
   },
   "flag_bs": {
-    "unicode": "1F1E7-1F1F8",
+    "unicode": "1f1e7-1F1F8",
     "unicode_alternates": [],
     "name": "the bahamas",
     "shortname": ":flag_bs:",
@@ -19428,7 +19428,7 @@
     ]
   },
   "flag_bh": {
-    "unicode": "1F1E7-1F1ED",
+    "unicode": "1f1e7-1F1ED",
     "unicode_alternates": [],
     "name": "bahrain",
     "shortname": ":flag_bh:",
@@ -19446,7 +19446,7 @@
     ]
   },
   "flag_bd": {
-    "unicode": "1F1E7-1F1E9",
+    "unicode": "1f1e7-1F1E9",
     "unicode_alternates": [],
     "name": "bangladesh",
     "shortname": ":flag_bd:",
@@ -19463,7 +19463,7 @@
     ]
   },
   "flag_bb": {
-    "unicode": "1F1E7-1F1E7",
+    "unicode": "1f1e7-1F1E7",
     "unicode_alternates": [],
     "name": "barbados",
     "shortname": ":flag_bb:",
@@ -19480,7 +19480,7 @@
     ]
   },
   "flag_by": {
-    "unicode": "1F1E7-1F1FE",
+    "unicode": "1f1e7-1F1FE",
     "unicode_alternates": [],
     "name": "belarus",
     "shortname": ":flag_by:",
@@ -19498,7 +19498,7 @@
     ]
   },
   "flag_bz": {
-    "unicode": "1F1E7-1F1FF",
+    "unicode": "1f1e7-1F1FF",
     "unicode_alternates": [],
     "name": "belize",
     "shortname": ":flag_bz:",
@@ -19515,7 +19515,7 @@
     ]
   },
   "flag_bj": {
-    "unicode": "1F1E7-1F1EF",
+    "unicode": "1f1e7-1F1EF",
     "unicode_alternates": [],
     "name": "benin",
     "shortname": ":flag_bj:",
@@ -19532,7 +19532,7 @@
     ]
   },
   "flag_bm": {
-    "unicode": "1F1E7-1F1F2",
+    "unicode": "1f1e7-1F1F2",
     "unicode_alternates": [],
     "name": "bermuda",
     "shortname": ":flag_bm:",
@@ -19549,7 +19549,7 @@
     ]
   },
   "flag_bt": {
-    "unicode": "1F1E7-1F1F9",
+    "unicode": "1f1e7-1F1F9",
     "unicode_alternates": [],
     "name": "bhutan",
     "shortname": ":flag_bt:",
@@ -19566,7 +19566,7 @@
     ]
   },
   "flag_bo": {
-    "unicode": "1F1E7-1F1F4",
+    "unicode": "1f1e7-1F1F4",
     "unicode_alternates": [],
     "name": "bolivia",
     "shortname": ":flag_bo:",
@@ -19583,7 +19583,7 @@
     ]
   },
   "flag_ba": {
-    "unicode": "1F1E7-1F1E6",
+    "unicode": "1f1e7-1F1E6",
     "unicode_alternates": [],
     "name": "bosnia and herzegovina",
     "shortname": ":flag_ba:",
@@ -19601,7 +19601,7 @@
     ]
   },
   "flag_bw": {
-    "unicode": "1F1E7-1F1FC",
+    "unicode": "1f1e7-1F1FC",
     "unicode_alternates": [],
     "name": "botswana",
     "shortname": ":flag_bw:",
@@ -19618,7 +19618,7 @@
     ]
   },
   "flag_bn": {
-    "unicode": "1F1E7-1F1F3",
+    "unicode": "1f1e7-1F1F3",
     "unicode_alternates": [],
     "name": "brunei",
     "shortname": ":flag_bn:",
@@ -19635,7 +19635,7 @@
     ]
   },
   "flag_bg": {
-    "unicode": "1F1E7-1F1EC",
+    "unicode": "1f1e7-1F1EC",
     "unicode_alternates": [],
     "name": "bulgaria",
     "shortname": ":flag_bg:",
@@ -19652,7 +19652,7 @@
     ]
   },
   "flag_bf": {
-    "unicode": "1F1E7-1F1EB",
+    "unicode": "1f1e7-1F1EB",
     "unicode_alternates": [],
     "name": "burkina faso",
     "shortname": ":flag_bf:",
@@ -19669,7 +19669,7 @@
     ]
   },
   "flag_bi": {
-    "unicode": "1F1E7-1F1EE",
+    "unicode": "1f1e7-1F1EE",
     "unicode_alternates": [],
     "name": "burundi",
     "shortname": ":flag_bi:",
@@ -19686,7 +19686,7 @@
     ]
   },
   "flag_kh": {
-    "unicode": "1F1F0-1F1ED",
+    "unicode": "1f1f0-1F1ED",
     "unicode_alternates": [],
     "name": "cambodia",
     "shortname": ":flag_kh:",
@@ -19704,7 +19704,7 @@
     ]
   },
   "flag_cm": {
-    "unicode": "1F1E8-1F1F2",
+    "unicode": "1f1e8-1F1F2",
     "unicode_alternates": [],
     "name": "cameroon",
     "shortname": ":flag_cm:",
@@ -19721,7 +19721,7 @@
     ]
   },
   "flag_cv": {
-    "unicode": "1F1E8-1F1FB",
+    "unicode": "1f1e8-1F1FB",
     "unicode_alternates": [],
     "name": "cape verde",
     "shortname": ":flag_cv:",
@@ -19739,7 +19739,7 @@
     ]
   },
   "flag_ky": {
-    "unicode": "1F1F0-1F1FE",
+    "unicode": "1f1f0-1F1FE",
     "unicode_alternates": [],
     "name": "cayman islands",
     "shortname": ":flag_ky:",
@@ -19756,7 +19756,7 @@
     ]
   },
   "flag_cf": {
-    "unicode": "1F1E8-1F1EB",
+    "unicode": "1f1e8-1F1EB",
     "unicode_alternates": [],
     "name": "central african republic",
     "shortname": ":flag_cf:",
@@ -19773,7 +19773,7 @@
     ]
   },
   "flag_km": {
-    "unicode": "1F1F0-1F1F2",
+    "unicode": "1f1f0-1F1F2",
     "unicode_alternates": [],
     "name": "the comoros",
     "shortname": ":flag_km:",
@@ -19790,7 +19790,7 @@
     ]
   },
   "flag_cd": {
-    "unicode": "1F1E8-1F1E9",
+    "unicode": "1f1e8-1F1E9",
     "unicode_alternates": [],
     "name": "the democratic republic of the congo",
     "shortname": ":flag_cd:",
@@ -19809,7 +19809,7 @@
     ]
   },
   "flag_cg": {
-    "unicode": "1F1E8-1F1EC",
+    "unicode": "1f1e8-1F1EC",
     "unicode_alternates": [],
     "name": "the republic of the congo",
     "shortname": ":flag_cg:",
@@ -19826,7 +19826,7 @@
     ]
   },
   "flag_td": {
-    "unicode": "1F1F9-1F1E9",
+    "unicode": "1f1f9-1F1E9",
     "unicode_alternates": [],
     "name": "chad",
     "shortname": ":flag_td:",
@@ -19844,7 +19844,7 @@
     ]
   },
   "flag_cr": {
-    "unicode": "1F1E8-1F1F7",
+    "unicode": "1f1e8-1F1F7",
     "unicode_alternates": [],
     "name": "costa rica",
     "shortname": ":flag_cr:",
@@ -19861,7 +19861,7 @@
     ]
   },
   "flag_ci": {
-    "unicode": "1F1E8-1F1EE",
+    "unicode": "1f1e8-1F1EE",
     "unicode_alternates": [],
     "name": "cote d'ivoire",
     "shortname": ":flag_ci:",
@@ -19878,7 +19878,7 @@
     ]
   },
   "flag_hr": {
-    "unicode": "1F1ED-1F1F7",
+    "unicode": "1f1ed-1F1F7",
     "unicode_alternates": [],
     "name": "croatia",
     "shortname": ":flag_hr:",
@@ -19896,7 +19896,7 @@
     ]
   },
   "flag_cu": {
-    "unicode": "1F1E8-1F1FA",
+    "unicode": "1f1e8-1F1FA",
     "unicode_alternates": [],
     "name": "cuba",
     "shortname": ":flag_cu:",
@@ -19913,7 +19913,7 @@
     ]
   },
   "flag_cy": {
-    "unicode": "1F1E8-1F1FE",
+    "unicode": "1f1e8-1F1FE",
     "unicode_alternates": [],
     "name": "cyprus",
     "shortname": ":flag_cy:",
@@ -19932,7 +19932,7 @@
     ]
   },
   "flag_cz": {
-    "unicode": "1F1E8-1F1FF",
+    "unicode": "1f1e8-1F1FF",
     "unicode_alternates": [],
     "name": "the czech republic",
     "shortname": ":flag_cz:",
@@ -19950,7 +19950,7 @@
     ]
   },
   "flag_dj": {
-    "unicode": "1F1E9-1F1EF",
+    "unicode": "1f1e9-1F1EF",
     "unicode_alternates": [],
     "name": "djibouti",
     "shortname": ":flag_dj:",
@@ -19967,7 +19967,7 @@
     ]
   },
   "flag_dm": {
-    "unicode": "1F1E9-1F1F2",
+    "unicode": "1f1e9-1F1F2",
     "unicode_alternates": [],
     "name": "dominica",
     "shortname": ":flag_dm:",
@@ -19984,7 +19984,7 @@
     ]
   },
   "flag_do": {
-    "unicode": "1F1E9-1F1F4",
+    "unicode": "1f1e9-1F1F4",
     "unicode_alternates": [],
     "name": "the dominican republic",
     "shortname": ":flag_do:",
@@ -20001,7 +20001,7 @@
     ]
   },
   "flag_tl": {
-    "unicode": "1F1F9-1F1F1",
+    "unicode": "1f1f9-1F1F1",
     "unicode_alternates": [],
     "name": "east timor",
     "shortname": ":flag_tl:",
@@ -20018,7 +20018,7 @@
     ]
   },
   "flag_ec": {
-    "unicode": "1F1EA-1F1E8",
+    "unicode": "1f1ea-1F1E8",
     "unicode_alternates": [],
     "name": "ecuador",
     "shortname": ":flag_ec:",
@@ -20035,7 +20035,7 @@
     ]
   },
   "flag_eg": {
-    "unicode": "1F1EA-1F1EC",
+    "unicode": "1f1ea-1F1EC",
     "unicode_alternates": [],
     "name": "egypt",
     "shortname": ":flag_eg:",
@@ -20053,7 +20053,7 @@
     ]
   },
   "flag_sv": {
-    "unicode": "1F1F8-1F1FB",
+    "unicode": "1f1f8-1F1FB",
     "unicode_alternates": [],
     "name": "el salvador",
     "shortname": ":flag_sv:",
@@ -20070,7 +20070,7 @@
     ]
   },
   "flag_gq": {
-    "unicode": "1F1EC-1F1F6",
+    "unicode": "1f1ec-1F1F6",
     "unicode_alternates": [],
     "name": "equatorial guinea",
     "shortname": ":flag_gq:",
@@ -20088,7 +20088,7 @@
     ]
   },
   "flag_er": {
-    "unicode": "1F1EA-1F1F7",
+    "unicode": "1f1ea-1F1F7",
     "unicode_alternates": [],
     "name": "eritrea",
     "shortname": ":flag_er:",
@@ -20106,7 +20106,7 @@
     ]
   },
   "flag_ee": {
-    "unicode": "1F1EA-1F1EA",
+    "unicode": "1f1ea-1F1EA",
     "unicode_alternates": [],
     "name": "estonia",
     "shortname": ":flag_ee:",
@@ -20124,7 +20124,7 @@
     ]
   },
   "flag_et": {
-    "unicode": "1F1EA-1F1F9",
+    "unicode": "1f1ea-1F1F9",
     "unicode_alternates": [],
     "name": "ethiopia",
     "shortname": ":flag_et:",
@@ -20143,7 +20143,7 @@
     ]
   },
   "flag_fk": {
-    "unicode": "1F1EB-1F1F0",
+    "unicode": "1f1eb-1F1F0",
     "unicode_alternates": [],
     "name": "falkland islands",
     "shortname": ":flag_fk:",
@@ -20161,7 +20161,7 @@
     ]
   },
   "flag_fo": {
-    "unicode": "1F1EB-1F1F4",
+    "unicode": "1f1eb-1F1F4",
     "unicode_alternates": [],
     "name": "faroe islands",
     "shortname": ":flag_fo:",
@@ -20179,7 +20179,7 @@
     ]
   },
   "flag_fj": {
-    "unicode": "1F1EB-1F1EF",
+    "unicode": "1f1eb-1F1EF",
     "unicode_alternates": [],
     "name": "fiji",
     "shortname": ":flag_fj:",
@@ -20196,7 +20196,7 @@
     ]
   },
   "flag_pf": {
-    "unicode": "1F1F5-1F1EB",
+    "unicode": "1f1f5-1F1EB",
     "unicode_alternates": [],
     "name": "french polynesia",
     "shortname": ":flag_pf:",
@@ -20215,7 +20215,7 @@
     ]
   },
   "flag_ga": {
-    "unicode": "1F1EC-1F1E6",
+    "unicode": "1f1ec-1F1E6",
     "unicode_alternates": [],
     "name": "gabon",
     "shortname": ":flag_ga:",
@@ -20232,7 +20232,7 @@
     ]
   },
   "flag_gm": {
-    "unicode": "1F1EC-1F1F2",
+    "unicode": "1f1ec-1F1F2",
     "unicode_alternates": [],
     "name": "the gambia",
     "shortname": ":flag_gm:",
@@ -20249,7 +20249,7 @@
     ]
   },
   "flag_ge": {
-    "unicode": "1F1EC-1F1EA",
+    "unicode": "1f1ec-1F1EA",
     "unicode_alternates": [],
     "name": "georgia",
     "shortname": ":flag_ge:",
@@ -20268,7 +20268,7 @@
     ]
   },
   "flag_gh": {
-    "unicode": "1F1EC-1F1ED",
+    "unicode": "1f1ec-1F1ED",
     "unicode_alternates": [],
     "name": "ghana",
     "shortname": ":flag_gh:",
@@ -20285,7 +20285,7 @@
     ]
   },
   "flag_gi": {
-    "unicode": "1F1EC-1F1EE",
+    "unicode": "1f1ec-1F1EE",
     "unicode_alternates": [],
     "name": "gibraltar",
     "shortname": ":flag_gi:",
@@ -20302,7 +20302,7 @@
     ]
   },
   "flag_gr": {
-    "unicode": "1F1EC-1F1F7",
+    "unicode": "1f1ec-1F1F7",
     "unicode_alternates": [],
     "name": "greece",
     "shortname": ":flag_gr:",
@@ -20321,7 +20321,7 @@
     ]
   },
   "flag_gl": {
-    "unicode": "1F1EC-1F1F1",
+    "unicode": "1f1ec-1F1F1",
     "unicode_alternates": [],
     "name": "greenland",
     "shortname": ":flag_gl:",
@@ -20339,7 +20339,7 @@
     ]
   },
   "flag_gd": {
-    "unicode": "1F1EC-1F1E9",
+    "unicode": "1f1ec-1F1E9",
     "unicode_alternates": [],
     "name": "grenada",
     "shortname": ":flag_gd:",
@@ -20356,7 +20356,7 @@
     ]
   },
   "flag_gu": {
-    "unicode": "1F1EC-1F1FA",
+    "unicode": "1f1ec-1F1FA",
     "unicode_alternates": [],
     "name": "guam",
     "shortname": ":flag_gu:",
@@ -20373,7 +20373,7 @@
     ]
   },
   "flag_gt": {
-    "unicode": "1F1EC-1F1F9",
+    "unicode": "1f1ec-1F1F9",
     "unicode_alternates": [],
     "name": "guatemala",
     "shortname": ":flag_gt:",
@@ -20390,7 +20390,7 @@
     ]
   },
   "flag_gn": {
-    "unicode": "1F1EC-1F1F3",
+    "unicode": "1f1ec-1F1F3",
     "unicode_alternates": [],
     "name": "guinea",
     "shortname": ":flag_gn:",
@@ -20408,7 +20408,7 @@
     ]
   },
   "flag_gw": {
-    "unicode": "1F1EC-1F1FC",
+    "unicode": "1f1ec-1F1FC",
     "unicode_alternates": [],
     "name": "guinea-bissau",
     "shortname": ":flag_gw:",
@@ -20427,7 +20427,7 @@
     ]
   },
   "flag_gy": {
-    "unicode": "1F1EC-1F1FE",
+    "unicode": "1f1ec-1F1FE",
     "unicode_alternates": [],
     "name": "guyana",
     "shortname": ":flag_gy:",
@@ -20444,7 +20444,7 @@
     ]
   },
   "flag_ht": {
-    "unicode": "1F1ED-1F1F9",
+    "unicode": "1f1ed-1F1F9",
     "unicode_alternates": [],
     "name": "haiti",
     "shortname": ":flag_ht:",
@@ -20461,7 +20461,7 @@
     ]
   },
   "flag_hn": {
-    "unicode": "1F1ED-1F1F3",
+    "unicode": "1f1ed-1F1F3",
     "unicode_alternates": [],
     "name": "honduras",
     "shortname": ":flag_hn:",
@@ -20478,7 +20478,7 @@
     ]
   },
   "flag_hu": {
-    "unicode": "1F1ED-1F1FA",
+    "unicode": "1f1ed-1F1FA",
     "unicode_alternates": [],
     "name": "hungary",
     "shortname": ":flag_hu:",
@@ -20496,7 +20496,7 @@
     ]
   },
   "flag_is": {
-    "unicode": "1F1EE-1F1F8",
+    "unicode": "1f1ee-1F1F8",
     "unicode_alternates": [],
     "name": "iceland",
     "shortname": ":flag_is:",
@@ -20514,7 +20514,7 @@
     ]
   },
   "flag_ir": {
-    "unicode": "1F1EE-1F1F7",
+    "unicode": "1f1ee-1F1F7",
     "unicode_alternates": [],
     "name": "iran",
     "shortname": ":flag_ir:",
@@ -20531,7 +20531,7 @@
     ]
   },
   "flag_iq": {
-    "unicode": "1F1EE-1F1F6",
+    "unicode": "1f1ee-1F1F6",
     "unicode_alternates": [],
     "name": "iraq",
     "shortname": ":flag_iq:",
@@ -20548,7 +20548,7 @@
     ]
   },
   "flag_jm": {
-    "unicode": "1F1EF-1F1F2",
+    "unicode": "1f1ef-1F1F2",
     "unicode_alternates": [],
     "name": "jamaica",
     "shortname": ":flag_jm:",
@@ -20565,7 +20565,7 @@
     ]
   },
   "flag_je": {
-    "unicode": "1F1EF-1F1EA",
+    "unicode": "1f1ef-1F1EA",
     "unicode_alternates": [],
     "name": "jersey",
     "shortname": ":flag_je:",
@@ -20582,7 +20582,7 @@
     ]
   },
   "flag_jo": {
-    "unicode": "1F1EF-1F1F4",
+    "unicode": "1f1ef-1F1F4",
     "unicode_alternates": [],
     "name": "jordan",
     "shortname": ":flag_jo:",
@@ -20600,7 +20600,7 @@
     ]
   },
   "flag_kz": {
-    "unicode": "1F1F0-1F1FF",
+    "unicode": "1f1f0-1F1FF",
     "unicode_alternates": [],
     "name": "kazakhstan",
     "shortname": ":flag_kz:",
@@ -20618,7 +20618,7 @@
     ]
   },
   "flag_ke": {
-    "unicode": "1F1F0-1F1EA",
+    "unicode": "1f1f0-1F1EA",
     "unicode_alternates": [],
     "name": "kenya",
     "shortname": ":flag_ke:",
@@ -20635,7 +20635,7 @@
     ]
   },
   "flag_ki": {
-    "unicode": "1F1F0-1F1EE",
+    "unicode": "1f1f0-1F1EE",
     "unicode_alternates": [],
     "name": "kiribati",
     "shortname": ":flag_ki:",
@@ -20654,7 +20654,7 @@
     ]
   },
   "flag_xk": {
-    "unicode": "1F1FD-1F1F0",
+    "unicode": "1f1fd-1F1F0",
     "unicode_alternates": [],
     "name": "kosovo",
     "shortname": ":flag_xk:",
@@ -20671,7 +20671,7 @@
     ]
   },
   "flag_kw": {
-    "unicode": "1F1F0-1F1FC",
+    "unicode": "1f1f0-1F1FC",
     "unicode_alternates": [],
     "name": "kuwait",
     "shortname": ":flag_kw:",
@@ -20689,7 +20689,7 @@
     ]
   },
   "flag_kg": {
-    "unicode": "1F1F0-1F1EC",
+    "unicode": "1f1f0-1F1EC",
     "unicode_alternates": [],
     "name": "kyrgyzstan",
     "shortname": ":flag_kg:",
@@ -20707,7 +20707,7 @@
     ]
   },
   "flag_la": {
-    "unicode": "1F1F1-1F1E6",
+    "unicode": "1f1f1-1F1E6",
     "unicode_alternates": [],
     "name": "laos",
     "shortname": ":flag_la:",
@@ -20724,7 +20724,7 @@
     ]
   },
   "flag_lv": {
-    "unicode": "1F1F1-1F1FB",
+    "unicode": "1f1f1-1F1FB",
     "unicode_alternates": [],
     "name": "latvia",
     "shortname": ":flag_lv:",
@@ -20742,7 +20742,7 @@
     ]
   },
   "flag_lb": {
-    "unicode": "1F1F1-1F1E7",
+    "unicode": "1f1f1-1F1E7",
     "unicode_alternates": [],
     "name": "lebanon",
     "shortname": ":flag_lb:",
@@ -20760,7 +20760,7 @@
     ]
   },
   "flag_ls": {
-    "unicode": "1F1F1-1F1F8",
+    "unicode": "1f1f1-1F1F8",
     "unicode_alternates": [],
     "name": "lesotho",
     "shortname": ":flag_ls:",
@@ -20777,7 +20777,7 @@
     ]
   },
   "flag_lr": {
-    "unicode": "1F1F1-1F1F7",
+    "unicode": "1f1f1-1F1F7",
     "unicode_alternates": [],
     "name": "liberia",
     "shortname": ":flag_lr:",
@@ -20794,7 +20794,7 @@
     ]
   },
   "flag_ly": {
-    "unicode": "1F1F1-1F1FE",
+    "unicode": "1f1f1-1F1FE",
     "unicode_alternates": [],
     "name": "libya",
     "shortname": ":flag_ly:",
@@ -20812,7 +20812,7 @@
     ]
   },
   "flag_li": {
-    "unicode": "1F1F1-1F1EE",
+    "unicode": "1f1f1-1F1EE",
     "unicode_alternates": [],
     "name": "liechtenstein",
     "shortname": ":flag_li:",
@@ -20829,7 +20829,7 @@
     ]
   },
   "flag_lt": {
-    "unicode": "1F1F1-1F1F9",
+    "unicode": "1f1f1-1F1F9",
     "unicode_alternates": [],
     "name": "lithuania",
     "shortname": ":flag_lt:",
@@ -20847,7 +20847,7 @@
     ]
   },
   "flag_lu": {
-    "unicode": "1F1F1-1F1FA",
+    "unicode": "1f1f1-1F1FA",
     "unicode_alternates": [],
     "name": "luxembourg",
     "shortname": ":flag_lu:",
@@ -20866,7 +20866,7 @@
     ]
   },
   "flag_mk": {
-    "unicode": "1F1F2-1F1F0",
+    "unicode": "1f1f2-1F1F0",
     "unicode_alternates": [],
     "name": "macedonia",
     "shortname": ":flag_mk:",
@@ -20883,7 +20883,7 @@
     ]
   },
   "flag_mg": {
-    "unicode": "1F1F2-1F1EC",
+    "unicode": "1f1f2-1F1EC",
     "unicode_alternates": [],
     "name": "madagascar",
     "shortname": ":flag_mg:",
@@ -20900,7 +20900,7 @@
     ]
   },
   "flag_mw": {
-    "unicode": "1F1F2-1F1FC",
+    "unicode": "1f1f2-1F1FC",
     "unicode_alternates": [],
     "name": "malawi",
     "shortname": ":flag_mw:",
@@ -20917,7 +20917,7 @@
     ]
   },
   "flag_mv": {
-    "unicode": "1F1F2-1F1FB",
+    "unicode": "1f1f2-1F1FB",
     "unicode_alternates": [],
     "name": "maldives",
     "shortname": ":flag_mv:",
@@ -20935,7 +20935,7 @@
     ]
   },
   "flag_ml": {
-    "unicode": "1F1F2-1F1F1",
+    "unicode": "1f1f2-1F1F1",
     "unicode_alternates": [],
     "name": "mali",
     "shortname": ":flag_ml:",
@@ -20952,7 +20952,7 @@
     ]
   },
   "flag_mt": {
-    "unicode": "1F1F2-1F1F9",
+    "unicode": "1f1f2-1F1F9",
     "unicode_alternates": [],
     "name": "malta",
     "shortname": ":flag_mt:",
@@ -20969,7 +20969,7 @@
     ]
   },
   "flag_mh": {
-    "unicode": "1F1F2-1F1ED",
+    "unicode": "1f1f2-1F1ED",
     "unicode_alternates": [],
     "name": "the marshall islands",
     "shortname": ":flag_mh:",
@@ -20986,7 +20986,7 @@
     ]
   },
   "flag_mr": {
-    "unicode": "1F1F2-1F1F7",
+    "unicode": "1f1f2-1F1F7",
     "unicode_alternates": [],
     "name": "mauritania",
     "shortname": ":flag_mr:",
@@ -21004,7 +21004,7 @@
     ]
   },
   "flag_mu": {
-    "unicode": "1F1F2-1F1FA",
+    "unicode": "1f1f2-1F1FA",
     "unicode_alternates": [],
     "name": "mauritius",
     "shortname": ":flag_mu:",
@@ -21021,7 +21021,7 @@
     ]
   },
   "flag_fm": {
-    "unicode": "1F1EB-1F1F2",
+    "unicode": "1f1eb-1F1F2",
     "unicode_alternates": [],
     "name": "micronesia",
     "shortname": ":flag_fm:",
@@ -21038,7 +21038,7 @@
     ]
   },
   "flag_md": {
-    "unicode": "1F1F2-1F1E9",
+    "unicode": "1f1f2-1F1E9",
     "unicode_alternates": [],
     "name": "moldova",
     "shortname": ":flag_md:",
@@ -21055,7 +21055,7 @@
     ]
   },
   "flag_mc": {
-    "unicode": "1F1F2-1F1E8",
+    "unicode": "1f1f2-1F1E8",
     "unicode_alternates": [],
     "name": "monaco",
     "shortname": ":flag_mc:",
@@ -21072,7 +21072,7 @@
     ]
   },
   "flag_mn": {
-    "unicode": "1F1F2-1F1F3",
+    "unicode": "1f1f2-1F1F3",
     "unicode_alternates": [],
     "name": "mongolia",
     "shortname": ":flag_mn:",
@@ -21090,7 +21090,7 @@
     ]
   },
   "flag_me": {
-    "unicode": "1F1F2-1F1EA",
+    "unicode": "1f1f2-1F1EA",
     "unicode_alternates": [],
     "name": "montenegro",
     "shortname": ":flag_me:",
@@ -21108,7 +21108,7 @@
     ]
   },
   "flag_ms": {
-    "unicode": "1F1F2-1F1F8",
+    "unicode": "1f1f2-1F1F8",
     "unicode_alternates": [],
     "name": "montserrat",
     "shortname": ":flag_ms:",
@@ -21125,7 +21125,7 @@
     ]
   },
   "flag_ma": {
-    "unicode": "1F1F2-1F1E6",
+    "unicode": "1f1f2-1F1E6",
     "unicode_alternates": [],
     "name": "morocco",
     "shortname": ":flag_ma:",
@@ -21143,7 +21143,7 @@
     ]
   },
   "flag_mz": {
-    "unicode": "1F1F2-1F1FF",
+    "unicode": "1f1f2-1F1FF",
     "unicode_alternates": [],
     "name": "mozambique",
     "shortname": ":flag_mz:",
@@ -21161,7 +21161,7 @@
     ]
   },
   "flag_mm": {
-    "unicode": "1F1F2-1F1F2",
+    "unicode": "1f1f2-1F1F2",
     "unicode_alternates": [],
     "name": "myanmar",
     "shortname": ":flag_mm:",
@@ -21179,7 +21179,7 @@
     ]
   },
   "flag_na": {
-    "unicode": "1F1F3-1F1E6",
+    "unicode": "1f1f3-1F1E6",
     "unicode_alternates": [],
     "name": "namibia",
     "shortname": ":flag_na:",
@@ -21196,7 +21196,7 @@
     ]
   },
   "flag_nr": {
-    "unicode": "1F1F3-1F1F7",
+    "unicode": "1f1f3-1F1F7",
     "unicode_alternates": [],
     "name": "nauru",
     "shortname": ":flag_nr:",
@@ -21213,7 +21213,7 @@
     ]
   },
   "flag_np": {
-    "unicode": "1F1F3-1F1F5",
+    "unicode": "1f1f3-1F1F5",
     "unicode_alternates": [],
     "name": "nepal",
     "shortname": ":flag_np:",
@@ -21230,7 +21230,7 @@
     ]
   },
   "flag_nc": {
-    "unicode": "1F1F3-1F1E8",
+    "unicode": "1f1f3-1F1E8",
     "unicode_alternates": [],
     "name": "new caledonia",
     "shortname": ":flag_nc:",
@@ -21250,7 +21250,7 @@
     ]
   },
   "flag_ni": {
-    "unicode": "1F1F3-1F1EE",
+    "unicode": "1f1f3-1F1EE",
     "unicode_alternates": [],
     "name": "nicaragua",
     "shortname": ":flag_ni:",
@@ -21267,7 +21267,7 @@
     ]
   },
   "flag_ne": {
-    "unicode": "1F1F3-1F1EA",
+    "unicode": "1f1f3-1F1EA",
     "unicode_alternates": [],
     "name": "niger",
     "shortname": ":flag_ne:",
@@ -21284,7 +21284,7 @@
     ]
   },
   "flag_ng": {
-    "unicode": "1F1F3-1F1EC",
+    "unicode": "1f1f3-1F1EC",
     "unicode_alternates": [],
     "name": "nigeria",
     "shortname": ":flag_ng:",
@@ -21301,7 +21301,7 @@
     ]
   },
   "flag_nu": {
-    "unicode": "1F1F3-1F1FA",
+    "unicode": "1f1f3-1F1FA",
     "unicode_alternates": [],
     "name": "niue",
     "shortname": ":flag_nu:",
@@ -21318,7 +21318,7 @@
     ]
   },
   "flag_kp": {
-    "unicode": "1F1F0-1F1F5",
+    "unicode": "1f1f0-1F1F5",
     "unicode_alternates": [],
     "name": "north korea",
     "shortname": ":flag_kp:",
@@ -21335,7 +21335,7 @@
     ]
   },
   "flag_om": {
-    "unicode": "1F1F4-1F1F2",
+    "unicode": "1f1f4-1F1F2",
     "unicode_alternates": [],
     "name": "oman",
     "shortname": ":flag_om:",
@@ -21353,7 +21353,7 @@
     ]
   },
   "flag_pk": {
-    "unicode": "1F1F5-1F1F0",
+    "unicode": "1f1f5-1F1F0",
     "unicode_alternates": [],
     "name": "pakistan",
     "shortname": ":flag_pk:",
@@ -21370,7 +21370,7 @@
     ]
   },
   "flag_pw": {
-    "unicode": "1F1F5-1F1FC",
+    "unicode": "1f1f5-1F1FC",
     "unicode_alternates": [],
     "name": "palau",
     "shortname": ":flag_pw:",
@@ -21388,7 +21388,7 @@
     ]
   },
   "flag_ps": {
-    "unicode": "1F1F5-1F1F8",
+    "unicode": "1f1f5-1F1F8",
     "unicode_alternates": [],
     "name": "palestinian authority",
     "shortname": ":flag_ps:",
@@ -21405,7 +21405,7 @@
     ]
   },
   "flag_pa": {
-    "unicode": "1F1F5-1F1E6",
+    "unicode": "1f1f5-1F1E6",
     "unicode_alternates": [],
     "name": "panama",
     "shortname": ":flag_pa:",
@@ -21422,7 +21422,7 @@
     ]
   },
   "flag_pg": {
-    "unicode": "1F1F5-1F1EC",
+    "unicode": "1f1f5-1F1EC",
     "unicode_alternates": [],
     "name": "papua new guinea",
     "shortname": ":flag_pg:",
@@ -21440,7 +21440,7 @@
     ]
   },
   "flag_py": {
-    "unicode": "1F1F5-1F1FE",
+    "unicode": "1f1f5-1F1FE",
     "unicode_alternates": [],
     "name": "paraguay",
     "shortname": ":flag_py:",
@@ -21457,7 +21457,7 @@
     ]
   },
   "flag_pe": {
-    "unicode": "1F1F5-1F1EA",
+    "unicode": "1f1f5-1F1EA",
     "unicode_alternates": [],
     "name": "peru",
     "shortname": ":flag_pe:",
@@ -21474,7 +21474,7 @@
     ]
   },
   "flag_qa": {
-    "unicode": "1F1F6-1F1E6",
+    "unicode": "1f1f6-1F1E6",
     "unicode_alternates": [],
     "name": "qatar",
     "shortname": ":flag_qa:",
@@ -21492,7 +21492,7 @@
     ]
   },
   "flag_ro": {
-    "unicode": "1F1F7-1F1F4",
+    "unicode": "1f1f7-1F1F4",
     "unicode_alternates": [],
     "name": "romania",
     "shortname": ":flag_ro:",
@@ -21509,7 +21509,7 @@
     ]
   },
   "flag_rw": {
-    "unicode": "1F1F7-1F1FC",
+    "unicode": "1f1f7-1F1FC",
     "unicode_alternates": [],
     "name": "rwanda",
     "shortname": ":flag_rw:",
@@ -21526,7 +21526,7 @@
     ]
   },
   "flag_sh": {
-    "unicode": "1F1F8-1F1ED",
+    "unicode": "1f1f8-1F1ED",
     "unicode_alternates": [],
     "name": "saint helena",
     "shortname": ":flag_sh:",
@@ -21543,7 +21543,7 @@
     ]
   },
   "flag_kn": {
-    "unicode": "1F1F0-1F1F3",
+    "unicode": "1f1f0-1F1F3",
     "unicode_alternates": [],
     "name": "saint kitts and nevis",
     "shortname": ":flag_kn:",
@@ -21560,7 +21560,7 @@
     ]
   },
   "flag_lc": {
-    "unicode": "1F1F1-1F1E8",
+    "unicode": "1f1f1-1F1E8",
     "unicode_alternates": [],
     "name": "saint lucia",
     "shortname": ":flag_lc:",
@@ -21577,7 +21577,7 @@
     ]
   },
   "flag_vc": {
-    "unicode": "1F1FB-1F1E8",
+    "unicode": "1f1fb-1F1E8",
     "unicode_alternates": [],
     "name": "saint vincent and the grenadines",
     "shortname": ":flag_vc:",
@@ -21594,7 +21594,7 @@
     ]
   },
   "flag_ws": {
-    "unicode": "1F1FC-1F1F8",
+    "unicode": "1f1fc-1F1F8",
     "unicode_alternates": [],
     "name": "samoa",
     "shortname": ":flag_ws:",
@@ -21612,7 +21612,7 @@
     ]
   },
   "flag_sm": {
-    "unicode": "1F1F8-1F1F2",
+    "unicode": "1f1f8-1F1F2",
     "unicode_alternates": [],
     "name": "san marino",
     "shortname": ":flag_sm:",
@@ -21629,7 +21629,7 @@
     ]
   },
   "flag_st": {
-    "unicode": "1F1F8-1F1F9",
+    "unicode": "1f1f8-1F1F9",
     "unicode_alternates": [],
     "name": "sao tome and principe",
     "shortname": ":flag_st:",
@@ -21647,7 +21647,7 @@
     ]
   },
   "flag_sn": {
-    "unicode": "1F1F8-1F1F3",
+    "unicode": "1f1f8-1F1F3",
     "unicode_alternates": [],
     "name": "senegal",
     "shortname": ":flag_sn:",
@@ -21664,7 +21664,7 @@
     ]
   },
   "flag_rs": {
-    "unicode": "1F1F7-1F1F8",
+    "unicode": "1f1f7-1F1F8",
     "unicode_alternates": [],
     "name": "serbia",
     "shortname": ":flag_rs:",
@@ -21682,7 +21682,7 @@
     ]
   },
   "flag_sc": {
-    "unicode": "1F1F8-1F1E8",
+    "unicode": "1f1f8-1F1E8",
     "unicode_alternates": [],
     "name": "the seychelles",
     "shortname": ":flag_sc:",
@@ -21700,7 +21700,7 @@
     ]
   },
   "flag_sl": {
-    "unicode": "1F1F8-1F1F1",
+    "unicode": "1f1f8-1F1F1",
     "unicode_alternates": [],
     "name": "sierra leone",
     "shortname": ":flag_sl:",
@@ -21717,7 +21717,7 @@
     ]
   },
   "flag_sk": {
-    "unicode": "1F1F8-1F1F0",
+    "unicode": "1f1f8-1F1F0",
     "unicode_alternates": [],
     "name": "slovakia",
     "shortname": ":flag_sk:",
@@ -21734,7 +21734,7 @@
     ]
   },
   "flag_si": {
-    "unicode": "1F1F8-1F1EE",
+    "unicode": "1f1f8-1F1EE",
     "unicode_alternates": [],
     "name": "slovenia",
     "shortname": ":flag_si:",
@@ -21752,7 +21752,7 @@
     ]
   },
   "flag_sb": {
-    "unicode": "1F1F8-1F1E7",
+    "unicode": "1f1f8-1F1E7",
     "unicode_alternates": [],
     "name": "the solomon islands",
     "shortname": ":flag_sb:",
@@ -21769,7 +21769,7 @@
     ]
   },
   "flag_so": {
-    "unicode": "1F1F8-1F1F4",
+    "unicode": "1f1f8-1F1F4",
     "unicode_alternates": [],
     "name": "somalia",
     "shortname": ":flag_so:",
@@ -21786,7 +21786,7 @@
     ]
   },
   "flag_lk": {
-    "unicode": "1F1F1-1F1F0",
+    "unicode": "1f1f1-1F1F0",
     "unicode_alternates": [],
     "name": "sri lanka",
     "shortname": ":flag_lk:",
@@ -21803,7 +21803,7 @@
     ]
   },
   "flag_sd": {
-    "unicode": "1F1F8-1F1E9",
+    "unicode": "1f1f8-1F1E9",
     "unicode_alternates": [],
     "name": "sudan",
     "shortname": ":flag_sd:",
@@ -21821,7 +21821,7 @@
     ]
   },
   "flag_sr": {
-    "unicode": "1F1F8-1F1F7",
+    "unicode": "1f1f8-1F1F7",
     "unicode_alternates": [],
     "name": "suriname",
     "shortname": ":flag_sr:",
@@ -21838,7 +21838,7 @@
     ]
   },
   "flag_sz": {
-    "unicode": "1F1F8-1F1FF",
+    "unicode": "1f1f8-1F1FF",
     "unicode_alternates": [],
     "name": "swaziland",
     "shortname": ":flag_sz:",
@@ -21855,7 +21855,7 @@
     ]
   },
   "flag_sy": {
-    "unicode": "1F1F8-1F1FE",
+    "unicode": "1f1f8-1F1FE",
     "unicode_alternates": [],
     "name": "syria",
     "shortname": ":flag_sy:",
@@ -21872,7 +21872,7 @@
     ]
   },
   "flag_tw": {
-    "unicode": "1F1F9-1F1FC",
+    "unicode": "1f1f9-1F1FC",
     "unicode_alternates": [],
     "name": "the republic of china",
     "shortname": ":flag_tw:",
@@ -21890,7 +21890,7 @@
     ]
   },
   "flag_tj": {
-    "unicode": "1F1F9-1F1EF",
+    "unicode": "1f1f9-1F1EF",
     "unicode_alternates": [],
     "name": "tajikistan",
     "shortname": ":flag_tj:",
@@ -21908,7 +21908,7 @@
     ]
   },
   "flag_tz": {
-    "unicode": "1F1F9-1F1FF",
+    "unicode": "1f1f9-1F1FF",
     "unicode_alternates": [],
     "name": "tanzania",
     "shortname": ":flag_tz:",
@@ -21925,7 +21925,7 @@
     ]
   },
   "flag_th": {
-    "unicode": "1F1F9-1F1ED",
+    "unicode": "1f1f9-1F1ED",
     "unicode_alternates": [],
     "name": "thailand",
     "shortname": ":flag_th:",
@@ -21943,7 +21943,7 @@
     ]
   },
   "flag_tg": {
-    "unicode": "1F1F9-1F1EC",
+    "unicode": "1f1f9-1F1EC",
     "unicode_alternates": [],
     "name": "togo",
     "shortname": ":flag_tg:",
@@ -21961,7 +21961,7 @@
     ]
   },
   "flag_to": {
-    "unicode": "1F1F9-1F1F4",
+    "unicode": "1f1f9-1F1F4",
     "unicode_alternates": [],
     "name": "tonga",
     "shortname": ":flag_to:",
@@ -21978,7 +21978,7 @@
     ]
   },
   "flag_tt": {
-    "unicode": "1F1F9-1F1F9",
+    "unicode": "1f1f9-1F1F9",
     "unicode_alternates": [],
     "name": "trinidad and tobago",
     "shortname": ":flag_tt:",
@@ -21995,7 +21995,7 @@
     ]
   },
   "flag_tn": {
-    "unicode": "1F1F9-1F1F3",
+    "unicode": "1f1f9-1F1F3",
     "unicode_alternates": [],
     "name": "tunisia",
     "shortname": ":flag_tn:",
@@ -22013,7 +22013,7 @@
     ]
   },
   "flag_tm": {
-    "unicode": "1F1F9-1F1F2",
+    "unicode": "1f1f9-1F1F2",
     "unicode_alternates": [],
     "name": "turkmenistan",
     "shortname": ":flag_tm:",
@@ -22030,7 +22030,7 @@
     ]
   },
   "flag_tv": {
-    "unicode": "1F1F9-1F1FB",
+    "unicode": "1f1f9-1F1FB",
     "unicode_alternates": [],
     "name": "tuvalu",
     "shortname": ":flag_tv:",
@@ -22047,7 +22047,7 @@
     ]
   },
   "flag_vi": {
-    "unicode": "1F1FB-1F1EE",
+    "unicode": "1f1fb-1F1EE",
     "unicode_alternates": [],
     "name": "u.s. virgin islands",
     "shortname": ":flag_vi:",
@@ -22064,7 +22064,7 @@
     ]
   },
   "flag_ug": {
-    "unicode": "1F1FA-1F1EC",
+    "unicode": "1f1fa-1F1EC",
     "unicode_alternates": [],
     "name": "uganda",
     "shortname": ":flag_ug:",
@@ -22081,7 +22081,7 @@
     ]
   },
   "flag_ua": {
-    "unicode": "1F1FA-1F1E6",
+    "unicode": "1f1fa-1F1E6",
     "unicode_alternates": [],
     "name": "ukraine",
     "shortname": ":flag_ua:",
@@ -22099,7 +22099,7 @@
     ]
   },
   "flag_uy": {
-    "unicode": "1F1FA-1F1FE",
+    "unicode": "1f1fa-1F1FE",
     "unicode_alternates": [],
     "name": "uruguay",
     "shortname": ":flag_uy:",
@@ -22116,7 +22116,7 @@
     ]
   },
   "flag_uz": {
-    "unicode": "1F1FA-1F1FF",
+    "unicode": "1f1fa-1F1FF",
     "unicode_alternates": [],
     "name": "uzbekistan",
     "shortname": ":flag_uz:",
@@ -22134,7 +22134,7 @@
     ]
   },
   "flag_vu": {
-    "unicode": "1F1FB-1F1FA",
+    "unicode": "1f1fb-1F1FA",
     "unicode_alternates": [],
     "name": "vanuatu",
     "shortname": ":flag_vu:",
@@ -22151,7 +22151,7 @@
     ]
   },
   "flag_va": {
-    "unicode": "1F1FB-1F1E6",
+    "unicode": "1f1fb-1F1E6",
     "unicode_alternates": [],
     "name": "the vatican city",
     "shortname": ":flag_va:",
@@ -22168,7 +22168,7 @@
     ]
   },
   "flag_ve": {
-    "unicode": "1F1FB-1F1EA",
+    "unicode": "1f1fb-1F1EA",
     "unicode_alternates": [],
     "name": "venezuela",
     "shortname": ":flag_ve:",
@@ -22185,7 +22185,7 @@
     ]
   },
   "flag_wf": {
-    "unicode": "1F1FC-1F1EB",
+    "unicode": "1f1fc-1F1EB",
     "unicode_alternates": [],
     "name": "wallis and futuna",
     "shortname": ":flag_wf:",
@@ -22202,7 +22202,7 @@
     ]
   },
   "flag_eh": {
-    "unicode": "1F1EA-1F1ED",
+    "unicode": "1f1ea-1F1ED",
     "unicode_alternates": [],
     "name": "western sahara",
     "shortname": ":flag_eh:",
@@ -22222,7 +22222,7 @@
     ]
   },
   "flag_ye": {
-    "unicode": "1F1FE-1F1EA",
+    "unicode": "1f1fe-1F1EA",
     "unicode_alternates": [],
     "name": "yemen",
     "shortname": ":flag_ye:",
@@ -22240,7 +22240,7 @@
     ]
   },
   "flag_zm": {
-    "unicode": "1F1FF-1F1F2",
+    "unicode": "1f1ff-1F1F2",
     "unicode_alternates": [],
     "name": "zambia",
     "shortname": ":flag_zm:",
@@ -22257,7 +22257,7 @@
     ]
   },
   "flag_zw": {
-    "unicode": "1F1FF-1F1FC",
+    "unicode": "1f1ff-1F1FC",
     "unicode_alternates": [],
     "name": "zimbabwe",
     "shortname": ":flag_zw:",

--- a/js/imojify.js
+++ b/js/imojify.js
@@ -1,14 +1,15 @@
-function imojify(scope) {
+function imojify(scope, options) {
   scope = scope || '.imojify';
+  options = options || {};
   var emojiRe = /:([\w-\+]+):/g;
   var cssEmojis;
   var elementsToReplace = document.querySelectorAll(scope);
+  var elementsToIgnore = document.querySelectorAll(options.ignore);
   for (var i = 0; i < elementsToReplace.length; i++) {
     imojify_node(elementsToReplace[i]);
   }
 
   function emojiExists(selector) {
-
     // find any emojis that have css rules to support them
     if(!cssEmojis){
       cssEmojis = {};
@@ -49,8 +50,8 @@ function imojify(scope) {
           node.data = post;
         }
       });
-    } else if (node.constructor === HTMLScriptElement) {
-      // Don't process text inside script tags
+    } else if (node.constructor === HTMLScriptElement || [].indexOf.call(elementsToIgnore, node) >= 0) {
+      // Don't process text inside script tags or ignored elements
       return;
     } else {
       var childNodes = node.childNodes;


### PR DESCRIPTION
Fixes #16  - Add ignore class

Takes in an optional `options` object that can provide a `ignore` property in the style of a selector (anything that `document.querySelector` can handle).
